### PR TITLE
Make changes to have wechat-rails running in Ruby 1.9

### DIFF
--- a/lib/wechat/message.rb
+++ b/lib/wechat/message.rb
@@ -20,12 +20,25 @@ module Wechat
     class ArticleBuilder
       attr_reader :items
       delegate :count, to: :items
-      def initialize 
+      def initialize
         @items=Array.new
       end
 
-      def item title: "title", description: nil, pic_url: nil, url: nil
-        items << {:Title=> title, :Description=> description, :PicUrl=> pic_url, :Url=> url}
+      def item options
+        default_options = {
+          :title => 'title',
+          :description => nil,
+          :pic_url => nil,
+          :url => nil
+        }
+        options.reverse_merge!(default_options)
+
+        items << {
+          :Title=> options[:title],
+          :Description=> options[:description],
+          :PicUrl=> options[:pic_url],
+          :Url=> options[:url]
+        }
       end
     end
 
@@ -41,8 +54,8 @@ module Wechat
 
     def reply
       Message.new(
-        :ToUserName=>message_hash[:FromUserName], 
-        :FromUserName=>message_hash[:ToUserName], 
+        :ToUserName=>message_hash[:FromUserName],
+        :FromUserName=>message_hash[:ToUserName],
         :CreateTime=>Time.now.to_i
       )
     end
@@ -56,7 +69,7 @@ module Wechat
         Wechat.api.media(message_hash[:MediaId])
 
       when :location
-        message_hash.slice(:Location_X, :Location_Y, :Scale, :Label).inject({}){|results, value| 
+        message_hash.slice(:Location_X, :Location_Y, :Scale, :Label).inject({}){|results, value|
           results[value[0].to_s.underscore.to_sym] = value[1]; results}
       else
         raise "Don't know how to parse message as #{type}"
@@ -95,12 +108,12 @@ module Wechat
         collection.each{|item| yield(article, item)}
         items = article.items
       else
-        items = collection.collect do |item| 
-         camelize_hash_keys(item.symbolize_keys.slice(:title, :description, :pic_url, :url))
+        items = collection.collect do |item|
+          camelize_hash_keys(item.symbolize_keys.slice(:title, :description, :pic_url, :url))
         end
       end
 
-      update(:MsgType=>"news", :ArticleCount=> items.count, 
+      update(:MsgType=>"news", :ArticleCount=> items.count,
         :Articles=> items.collect{|item| camelize_hash_keys(item)})
     end
 
@@ -132,11 +145,11 @@ module Wechat
 
     private
     def camelize_hash_keys hash
-      deep_recursive(hash){|key, value| [key.to_s.camelize.to_sym, value]} 
+      deep_recursive(hash){|key, value| [key.to_s.camelize.to_sym, value]}
     end
 
     def underscore_hash_keys hash
-      deep_recursive(hash){|key, value| [key.to_s.underscore.to_sym, value]} 
+      deep_recursive(hash){|key, value| [key.to_s.underscore.to_sym, value]}
     end
 
     def update fields={}

--- a/lib/wechat/responder.rb
+++ b/lib/wechat/responder.rb
@@ -2,7 +2,7 @@ module Wechat
   module Responder
     extend ActiveSupport::Concern
 
-    included do 
+    included do
       self.skip_before_filter :verify_authenticity_token
       self.before_filter :verify_signature, only: [:show, :create]
       #delegate :wehcat, to: :class
@@ -12,12 +12,24 @@ module Wechat
 
       attr_accessor :wechat, :token
 
-      def on message_type, with: nil, respond: nil, &block
-        raise "Unknow message type" unless message_type.in? [:text, :image, :voice, :video, :location, :link, :event, :fallback]
-        config=respond.nil? ? {} : {:respond=>respond}
-        config.merge!(:proc=>block) if block_given?
+      def on message_type, options={}, &block
+        default_options = {
+          :with => nil,
+          :respond => nil,
+        }
+        options.reverse_merge!(default_options)
 
-        if (with.present? && !message_type.in?([:text, :event]))
+        raise "Unknow message type" unless [:text, :image, :voice, :video, :location, :link, :event, :fallback].include? message_type
+
+        with = options[:with]
+        respond = options[:respond]
+
+        config = {}
+        config.merge!(:proc=>block) if block_given?
+        config.merge!(:respond=>resond) if respond.present?
+        config.merge!(:with=>with) if with.present?
+
+        if (with.present? && !([:text, :event].include?(message_type)))
           raise "Only text and event message can take :with parameters"
         else
           config.merge!(:with=>with) if with.present?
@@ -48,7 +60,7 @@ module Wechat
         end
       end
 
-      private 
+      private
 
       def match_responders responders, value
         matched = responders.inject({scoped:nil, general:nil}) do |matched, responder|
@@ -58,7 +70,7 @@ module Wechat
             matched[:general] ||= [responder, value]
             next matched
           end
-          
+
           if condition.is_a? Regexp
             matched[:scoped] ||= [responder] + $~.captures if(value =~ condition)
           else
@@ -66,11 +78,10 @@ module Wechat
           end
           matched
         end
-        return matched[:scoped] || matched[:general] 
+        return matched[:scoped] || matched[:general]
       end
     end
 
-    
     def show
       render :text => params[:echostr]
     end

--- a/wechat-rails.gemspec
+++ b/wechat-rails.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
   s.files = Dir["{bin app,config,lib}/**/*"] + ["LICENSE", "Rakefile", "README.md"]
   s.executables << 'wechat'
 
-  s.add_dependency "rails", ">= 3.2.14"
-  s.add_dependency "nokogiri", '>=1.6.0'
+  # s.add_dependency "rails", ">= 3.2.14"
+  # s.add_dependency "nokogiri", '>=1.6.0'
   s.add_dependency 'rest-client'
   s.add_development_dependency 'rspec-rails'
 end


### PR DESCRIPTION
1. Get rid of keyword arguments;
2. Use Array.include? to test if an element is in an array.

Some trailing white spaces are also cleaned up in this commit.
