### PR TITLE
bin/wechat:18:in `with': uninitialized constant App::Helper::YAML (NameE...

### DIFF
--- a/bin/wechat
+++ b/bin/wechat
@@ -8,7 +8,7 @@ require "wechat-rails"
 require 'json'  
 require "active_support/core_ext"
 require 'fileutils'
-
+require 'yaml'
 
 
 class App < Thor                                                 


### PR DESCRIPTION
 bin/wechat users
bin/wechat:18:in `with': uninitialized constant App::Helper::YAML (NameError)
  from bin/wechat:45:in`users'
  from /Users/john/.rvm/gems/ruby-2.1.2/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
  from /Users/john/.rvm/gems/ruby-2.1.2/gems/thor-0.19.1/lib/thor/invocation.rb:126:in`invoke_command'
  from /Users/john/.rvm/gems/ruby-2.1.2/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
  from /Users/john/.rvm/gems/ruby-2.1.2/gems/thor-0.19.1/lib/thor/base.rb:440:in`start'
  from bin/wechat:138:in `<main>'
