### PR TITLE
FIX invalid credential(40001)

### DIFF
--- a/lib/wechat-rails.rb
+++ b/lib/wechat-rails.rb
@@ -31,7 +31,7 @@ module Wechat
   end
 
   def self.api
-    Wechat::Api.new(self.config.appid, self.config.secret, self.config.access_token)
+    @api ||= Wechat::Api.new(self.config.appid, self.config.secret, self.config.access_token)
   end
 end
 


### PR DESCRIPTION
在rails中，使用直接使用Wechat.api来处理，token容易过期，出现invalid credential(40001)错误。
我这样的修复比较暴力 😊
