### PR TITLE
修正一定条件下access_token和jsapi_ticket会无限刷新

### DIFF
--- a/lib/wechat/access_token.rb
+++ b/lib/wechat/access_token.rb
@@ -23,7 +23,7 @@ module Wechat
 
     def refresh
       data = client.get('token', params: { grant_type: 'client_credential', appid: appid, secret: secret })
-      data.merge!(created_at: Time.now.to_i)
+      data.merge!('created_at' => Time.now.to_i)
       File.write(token_file, data.to_json) if valid_token(data)
       @token_data = data
     end

--- a/lib/wechat/jsapi_ticket.rb
+++ b/lib/wechat/jsapi_ticket.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'digest/sha1'
 
 module Wechat
@@ -34,7 +35,7 @@ module Wechat
     # 刷新 jsapi_ticket
     def refresh
       data = client.get('ticket/getticket', params: { access_token: access_token.token, type: 'jsapi' })
-      data.merge!(created_at: Time.now.to_i)
+      data.merge!('created_at' => Time.now.to_i)
       File.open(jsapi_ticket_file, 'w') { |f| f.write(data.to_json) } if valid_ticket(data)
       @jsapi_ticket_data = data
     end


### PR DESCRIPTION
1. 执行`refresh`方法
2. `token_data`中的`"created_at"`会变成`:created_at`
3. 之后每次执行`token`时，`token_data['created_at'].to_i`都是0
4. 那么只要当`Time.now.to_i >= 7200 - 3 * 60`，token就会一直判定失效，导致无限刷新刷新