### PR TITLE
Some small changes to fit wechat official API

### DIFF
--- a/bin/wechat
+++ b/bin/wechat
@@ -361,7 +361,7 @@ HELP
     if %w(image voice video file).include?(type)
       puts "errcode: #{r['errcode']} errmsg: #{r['errmsg']} total_count: #{r['total_count']} item_count: #{r['item_count']}"
       r['item'].each do |i|
-        puts "#{i['media_id']} #{i['filename']} #{Time.at(i['update_time'].to_i)}"
+        puts "#{i['media_id']} #{i['name']} #{Time.at(i['update_time'].to_i)}"
       end
     else
       puts r

--- a/bin/wechat
+++ b/bin/wechat
@@ -360,7 +360,7 @@ HELP
     r = Helper.with(options).material_list(type, offset, count)
     if %w(image voice video file).include?(type)
       puts "errcode: #{r['errcode']} errmsg: #{r['errmsg']} total_count: #{r['total_count']} item_count: #{r['item_count']}"
-      r['itemlist'].each do |i|
+      r['item'].each do |i|
         puts "#{i['media_id']} #{i['filename']} #{Time.at(i['update_time'].to_i)}"
       end
     else

--- a/lib/wechat/api.rb
+++ b/lib/wechat/api.rb
@@ -85,15 +85,15 @@ module Wechat
     end
 
     def media(media_id)
-      get 'media/get', params: { media_id: media_id }, base: FILE_BASE, as: :file
+      get 'media/get', params: { media_id: media_id }, base: API_BASE, as: :file
     end
 
     def media_create(type, file)
-      post 'media/upload', { upload: { media: file } }, params: { type: type }, base: FILE_BASE
+      post 'media/upload', { upload: { media: file } }, params: { type: type }, base: API_BASE
     end
 
     def material(media_id)
-      get 'material/get', params: { media_id: media_id }, base: FILE_BASE, as: :file
+      get 'material/get', params: { media_id: media_id }, base: API_BASE, as: :file
     end
 
     def material_count
@@ -105,7 +105,7 @@ module Wechat
     end
 
     def material_add(type, file)
-      post 'material/add_material', { upload: { media: file } }, params: { type: type }, base: FILE_BASE
+      post 'material/add_material', { upload: { media: file } }, params: { type: type }, base: API_BASE
     end
 
     def material_delete(media_id)

--- a/lib/wechat/cipher.rb
+++ b/lib/wechat/cipher.rb
@@ -14,11 +14,11 @@ module Wechat
       cipher.encrypt
 
       cipher.padding = 0
-      key_data = Base64.decode64(encoding_aes_key)
+      key_data = Base64.decode64(encoding_aes_key+'=')
       cipher.key = key_data
       cipher.iv = key_data[0..16]
 
-      cipher.update(encode_padding(plain)) + cipher.final
+      cipher.update(plain) + cipher.final
     end
 
     def decrypt(msg, encoding_aes_key)
@@ -26,7 +26,7 @@ module Wechat
       cipher.decrypt
 
       cipher.padding = 0
-      key_data = Base64.decode64(encoding_aes_key)
+      key_data = Base64.decode64(encoding_aes_key+'=')
       cipher.key = key_data
       cipher.iv = key_data[0..16]
 

--- a/lib/wechat/responder.rb
+++ b/lib/wechat/responder.rb
@@ -145,12 +145,20 @@ module Wechat
     private
 
     def verify_signature
-      signature = params[:signature] || params[:msg_signature]
+      signature = params[:signature]
+      msg_encrypt = nil
+
+      return render text: 'Forbidden', status: 403 if signature != Signature.hexdigest(self.class.token,
+                                                                                params[:timestamp],
+                                                                                params[:nonce],
+                                                                                msg_encrypt)
+
+      signature = params[:msg_signature]
 
       msg_encrypt = params[:echostr] if self.class.corpid.present?
       msg_encrypt ||= request_encrypt_content if self.class.encrypt_mode
 
-      render text: 'Forbidden', status: 403 if signature != Signature.hexdigest(self.class.token,
+      return render text: 'Forbidden', status: 403 if signature.present? && signature != Signature.hexdigest(self.class.token,
                                                                                 params[:timestamp],
                                                                                 params[:nonce],
                                                                                 msg_encrypt)


### PR DESCRIPTION
1. Minor mistakes in bin/wechat
2. `FILE_BASE` API seems to be no more supported by wechat. `API_BASE` works well instead.
3. Mistakes in `verify_signature` when `params[:signature]` and `params[:msg_signature]` both exist.
4. `aes_key` should be appended `'='` when used to encode and decode according to wechat documents.
5. `encode_padding` is called twice when encoding msg. Result is not accepted by wechat server.