### PR TITLE
fix qr download 404 bug

### DIFF
--- a/lib/wechat/api_base.rb
+++ b/lib/wechat/api_base.rb
@@ -11,7 +11,7 @@ module Wechat
     end
 
     def qrcode(ticket)
-      client.get 'showqrcode', ticket: CGI.escape(ticket), base: MP_BASE, as: :file
+      client.get 'showqrcode', params: { ticket: ticket }, base: MP_BASE, as: :file
     end
 
     def media(media_id)

--- a/lib/wechat/api_base.rb
+++ b/lib/wechat/api_base.rb
@@ -1,5 +1,3 @@
-require 'cgi'
-
 module Wechat
   class ApiBase
     attr_reader :access_token, :client


### PR DESCRIPTION
404的原因有两个。
1. 丢掉了params: { }，所以RestClient就忽略了ticket参数
2. ticket无需CGI.escape，因为RestClient会自动escape params里面的值。