### PR TITLE
some times cannot get userid from wechat_oauth2 for corp account

### DIFF
--- a/lib/wechat/controller_api.rb
+++ b/lib/wechat/controller_api.rb
@@ -44,7 +44,9 @@ module Wechat
     end
 
     def wechat_corp_oauth2(oauth2_url)
-      if cookies.signed_or_encrypted[:we_deviceid].blank? && params[:code].blank?
+      if (cookies.signed_or_encrypted[:we_userid].blank? || 
+          cookies.signed_or_encrypted[:we_deviceid].blank? || 
+          cookies.signed_or_encrypted[:we_openid].blank? ) &&  params[:code].blank?
         redirect_to oauth2_url
       elsif cookies.signed_or_encrypted[:we_deviceid].blank? && params[:code].present? && params[:state] == wechat.jsapi_ticket.oauth2_state
         userinfo = wechat.getuserinfo(params[:code])

--- a/spec/lib/wechat/responder_corp_spec.rb
+++ b/spec/lib/wechat/responder_corp_spec.rb
@@ -302,6 +302,7 @@ RSpec.describe WechatCorpController, type: :controller do
         it 'will render page with proper cookies' do
           cookies.signed_or_encrypted[:we_userid] = 'userid'
           cookies.signed_or_encrypted[:we_deviceid] = 'deviceid'
+          cookies.signed_or_encrypted[:we_openid] = 'openid'
           get :oauth2_page
           expect(response.body).to eq 'userid'
         end


### PR DESCRIPTION
some times cannot get userid from wechat_oauth2 for corp account, so check we_userid, we_deviceid and we_openid present instead of we_deviceid single one

as see #103 