### PR TITLE
fix SSLv3 error by use TLSv1_client

### DIFF
--- a/lib/wechat/http_client.rb
+++ b/lib/wechat/http_client.rb
@@ -8,6 +8,7 @@ module Wechat
       @base = base
       HTTP.timeout(:global, write: timeout, connect: timeout, read: timeout)
       @ssl_context = OpenSSL::SSL::SSLContext.new
+      @ssl_context.ssl_version = :TLSv1_client
       @ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE if skip_verify_ssl
     end
 


### PR DESCRIPTION
> 配置跳过SSL认证

> Wechat服务器有报道曾出现RestClient::SSLCertificateNotVerified错误，此时可以选择关闭SSL验证。skip_verify_ssl: true

这个错误是由于使用 SSLv3 导致的，微信曾发过公告，不再支持 SSLv2、SSLv3

微信官方的声明： https://mp.weixin.qq.com/cgi-bin/announce?action=getannouncement&key=1414562353&version=6&lang=zh_CN

但是日常使用报错的概率并不是很高，猜测是微信服务集群没有完全升级，里面也只是部分机器禁用了 SSLv3

改成 TLS 后，未再看到此类报错 #128 

