### PR TITLE
apply opt and config together when loading controller_wechat, to simp…

### DIFF
--- a/lib/action_controller/wechat_responder.rb
+++ b/lib/action_controller/wechat_responder.rb
@@ -29,13 +29,18 @@ module ActionController
       Wechat.config.oauth2_cookie_duration ||= 1.hour
       self.oauth2_cookie_duration = opts[:oauth2_cookie_duration] || Wechat.config.oauth2_cookie_duration.to_i.seconds
 
+      corpsecret   = opts[:corpsecret]   || Wechat.config.corpsecret
+      access_token = opts[:access_token] || Wechat.config.access_token
+      jsapi_ticket = opts[:jsapi_ticket] || Wechat.config.jsapi_ticket
+      secret       = opts[:secret]       || Wechat.config.secret
+
       return self.wechat_api_client = Wechat.api if opts.empty?
       if corpid.present?
-        Wechat::CorpApi.new(corpid, opts[:corpsecret], opts[:access_token], \
-                            agentid, timeout, skip_verify_ssl, opts[:jsapi_ticket])
+        Wechat::CorpApi.new(corpid, corpsecret, access_token, \
+                            agentid, timeout, skip_verify_ssl, jsapi_ticket)
       else
-        Wechat::Api.new(appid, opts[:secret], opts[:access_token], \
-                        timeout, skip_verify_ssl, opts[:jsapi_ticket])
+        Wechat::Api.new(appid, secret, access_token, \
+                        timeout, skip_verify_ssl, jsapi_ticket)
       end
     end
   end


### PR DESCRIPTION
when different wechat_responders exist with only some parameters diff, like agentid, it is not necessary to copy corpsecret/etc again, just use Wechat.config as default.