### PR TITLE
Feature/multiple accounts

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -162,6 +162,25 @@ development:
 
 test:
   <<: *default
+
+ # Multiple Accounts
+ #
+ # wx2_development:
+ #  <<: *default
+ #  appid: "my_appid"
+ #  secret: "my_secret"
+ #  access_token: "tmp/wechat_access_token2"
+ #  jsapi_ticket: "tmp/wechat_jsapi_ticket2"
+ #
+ # wx2_test:
+ #  <<: *default
+ #  appid: "my_appid"
+ #  secret: "my_secret"
+ #
+ # wx2_production:
+ #  <<: *default
+ #  appid: "my_appid"
+ #  secret: "my_secret"
 ```
 
 ##### 配置优先级
@@ -179,6 +198,16 @@ Wechat服务器有报道曾出现[RestClient::SSLCertificateNotVerified](http://
 #### 为每个Responder配置不同的appid和secret
 
 有些情况下，单个Rails应用可能需要处理来自多个微信公众号的消息，您可以通过在`wechat_responder`和`wechat_api`后配置多个相关参数来支持多账号。
+
+```ruby
+class WechatFirstController < ActionController::Base
+   wechat_responder account: :new_account
+
+   on :text, with:"help", respond: "help content"
+end
+```
+
+或者直接完整配置
 
 ```ruby
 class WechatFirstController < ActionController::Base
@@ -472,19 +501,19 @@ template:
   data:
     first:
       value: "您好，您已报名成功"
-      color: "#0A0A0A"      
+      color: "#0A0A0A"
     keynote1:
       value: "XX活动"
-      color: "#CCCCCC"      
+      color: "#CCCCCC"
     keynote2:
       value: "2014年9月16日"
-      color: "#CCCCCC"     
+      color: "#CCCCCC"
     keynote3:
       value: "上海徐家汇xxx城"
-      color: "#CCCCCC"                 
+      color: "#CCCCCC"
     remark:
       value: "欢迎再次使用。"
-      color: "#173177"          
+      color: "#173177"
 
 ```
 
@@ -619,7 +648,7 @@ class WechatsController < ActionController::Base
   # 处理地理位置消息
   on :label_location do |request|
     request.reply.text("Label: #{request[:Label]} Location_X: #{request[:Location_X]} Location_Y: #{request[:Location_Y]} Scale: #{request[:Scale]}")
-  end  
+  end
 
   # 处理上报地理位置事件
   on :location do |request|

--- a/README.md
+++ b/README.md
@@ -175,6 +175,25 @@ development:
 
 test:
   <<: *default
+
+ # Multiple Accounts
+ #
+ # wx2_development:
+ #  <<: *default
+ #  appid: "my_appid"
+ #  secret: "my_secret"
+ #  access_token: "tmp/wechat_access_token2"
+ #  jsapi_ticket: "tmp/wechat_jsapi_ticket2"
+ #
+ # wx2_test:
+ #  <<: *default
+ #  appid: "my_appid"
+ #  secret: "my_secret"
+ #
+ # wx2_production:
+ #  <<: *default
+ #  appid: "my_appid"
+ #  secret: "my_secret"
 ```
 
 ##### Configure priority
@@ -187,11 +206,20 @@ Stability various even for Tencent wechat server, so setting a long timeout may 
 
 ##### Skip the SSL verification
 
-SSL Certification can also be corrupted by some reason in China, [it's reported](http://qydev.weixin.qq.com/qa/index.php?qa=11037) and if it's happen to you, can setting `skip_verify_ssl: true`. (not recommend)  
+SSL Certification can also be corrupted by some reason in China, [it's reported](http://qydev.weixin.qq.com/qa/index.php?qa=11037) and if it's happen to you, can setting `skip_verify_ssl: true`. (not recommend)
 
 #### Configure individual responder with different appid
 
 Sometime, you may want to hosting more than one enterprise/public wechat account in one Rails application, so you can given those configuration info when calling `wechat_responder` or `wechat_api`
+
+```ruby
+class WechatFirstController < ActionController::Base
+   wechat_responder account: :new_account
+
+   on :text, with:"help", respond: "help content"
+end
+
+Or you can config full options.
 
 ```ruby
 class WechatFirstController < ActionController::Base
@@ -487,19 +515,19 @@ template:
   data:
     first:
       value: "Hello, you successfully registed"
-      color: "#0A0A0A"      
+      color: "#0A0A0A"
     keynote1:
       value: "5km Health Running"
-      color: "#CCCCCC"      
+      color: "#CCCCCC"
     keynote2:
       value: "2014-09-16"
-      color: "#CCCCCC"     
+      color: "#CCCCCC"
     keynote3:
       value: "Centry Park, Pudong, Shanghai"
-      color: "#CCCCCC"                 
+      color: "#CCCCCC"
     remark:
       value: "Welcome back"
-      color: "#173177"          
+      color: "#173177"
 
 ```
 

--- a/bin/wechat
+++ b/bin/wechat
@@ -18,6 +18,7 @@ require 'cgi'
 class App < Thor
   package_name 'Wechat'
   option :token_file, aliases: '-t', desc: 'File to store access token'
+  option :account, aliases: '-a', desc: 'Name of Wechat account configuration.Uses default when missing.'
 
   attr_reader :wechat_api_client
   no_commands do

--- a/bin/wechat
+++ b/bin/wechat
@@ -17,8 +17,7 @@ require 'cgi'
 
 class App < Thor
   package_name 'Wechat'
-  option :token_file, aliases: '-t', desc: 'File to store access token'
-  option :account, aliases: '-a', desc: 'Name of Wechat account configuration.Uses default when missing.'
+  class_option :account, aliases: '-a', default: :default, desc: 'Name of Wechat account configuration.'
 
   attr_reader :wechat_api_client
   no_commands do
@@ -27,6 +26,7 @@ class App < Thor
     end
   end
 
+  option :token_file, aliases: '-t', desc: 'File to store access token'
   desc 'callbackip', '获取微信服务器IP地址'
   def callbackip
     puts wechat_api.callbackip

--- a/lib/action_controller/wechat_responder.rb
+++ b/lib/action_controller/wechat_responder.rb
@@ -17,28 +17,34 @@ module ActionController
     private
 
     def load_controller_wechat(opts = {})
-      self.token = opts[:token] || Wechat.config.token
-      self.appid = opts[:appid] || Wechat.config.appid
-      self.corpid = opts[:corpid] || Wechat.config.corpid
-      self.agentid = opts[:agentid] || Wechat.config.agentid
-      self.encrypt_mode = opts[:encrypt_mode] || Wechat.config.encrypt_mode || corpid.present?
+      if opts.is_a?(Symbol) || opts.is_a?(String)
+        account = opts.to_sym
+        opts = {}
+      else
+        account = :default
+      end
+      self.token = opts[:token] || Wechat.config(account).token
+      self.appid = opts[:appid] || Wechat.config(account).appid
+      self.corpid = opts[:corpid] || Wechat.config(account).corpid
+      self.agentid = opts[:agentid] || Wechat.config(account).agentid
+      self.encrypt_mode = opts[:encrypt_mode] || Wechat.config(account).encrypt_mode || corpid.present?
       self.timeout = opts[:timeout] || 20
       self.skip_verify_ssl = opts[:skip_verify_ssl]
-      self.encoding_aes_key = opts[:encoding_aes_key] || Wechat.config.encoding_aes_key
-      self.trusted_domain_fullname = opts[:trusted_domain_fullname] || Wechat.config.trusted_domain_fullname
-      Wechat.config.oauth2_cookie_duration ||= 1.hour
-      self.oauth2_cookie_duration = opts[:oauth2_cookie_duration] || Wechat.config.oauth2_cookie_duration.to_i.seconds
+      self.encoding_aes_key = opts[:encoding_aes_key] || Wechat.config(account).encoding_aes_key
+      self.trusted_domain_fullname = opts[:trusted_domain_fullname] || Wechat.config(account).trusted_domain_fullname
+      Wechat.config(account).oauth2_cookie_duration ||= 1.hour
+      self.oauth2_cookie_duration = opts[:oauth2_cookie_duration] || Wechat.config(account).oauth2_cookie_duration.to_i.seconds
 
-      access_token = opts[:access_token] || Wechat.config.access_token
-      jsapi_ticket = opts[:jsapi_ticket] || Wechat.config.jsapi_ticket
+      access_token = opts[:access_token] || Wechat.config(account).access_token
+      jsapi_ticket = opts[:jsapi_ticket] || Wechat.config(account).jsapi_ticket
 
-      return self.wechat_api_client = Wechat.api if opts.empty?
+      return self.wechat_api_client = Wechat.api if account == :default && opts.empty?
       if corpid.present?
-        corpsecret = opts[:corpsecret] || Wechat.config.corpsecret
+        corpsecret = opts[:corpsecret] || Wechat.config(account).corpsecret
         Wechat::CorpApi.new(corpid, corpsecret, access_token, \
                             agentid, timeout, skip_verify_ssl, jsapi_ticket)
       else
-        secret = opts[:secret] || Wechat.config.secret
+        secret = opts[:secret] || Wechat.config(account).secret
         Wechat::Api.new(appid, secret, access_token, \
                         timeout, skip_verify_ssl, jsapi_ticket)
       end

--- a/lib/action_controller/wechat_responder.rb
+++ b/lib/action_controller/wechat_responder.rb
@@ -17,12 +17,8 @@ module ActionController
     private
 
     def load_controller_wechat(opts = {})
-      if opts.is_a?(Symbol) || opts.is_a?(String)
-        account = opts.to_sym
-        opts = {}
-      else
-        account = :default
-      end
+      account = opts[:account].present? ? opts[:account].to_sym : :default
+
       self.token = opts[:token] || Wechat.config(account).token
       self.appid = opts[:appid] || Wechat.config(account).appid
       self.corpid = opts[:corpid] || Wechat.config(account).corpid
@@ -39,6 +35,7 @@ module ActionController
       jsapi_ticket = opts[:jsapi_ticket] || Wechat.config(account).jsapi_ticket
 
       return self.wechat_api_client = Wechat.api if account == :default && opts.empty?
+
       if corpid.present?
         corpsecret = opts[:corpsecret] || Wechat.config(account).corpsecret
         Wechat::CorpApi.new(corpid, corpsecret, access_token, \

--- a/lib/generators/wechat/templates/config/initializers/wechat_redis_store.rb
+++ b/lib/generators/wechat/templates/config/initializers/wechat_redis_store.rb
@@ -7,11 +7,17 @@ module Wechat
   module Token
     class AccessTokenBase
       def read_token
-        JSON.parse(Wechat.redis.get('my_app_wechat_token'))
+        JSON.parse(Wechat.redis.get(redis_key))
       end
 
       def write_token(token_hash)
-        Wechat.redis.set 'my_app_wechat_token', token_hash.to_json
+        Wechat.redis.set redis_key, token_hash.to_json
+      end
+
+      private
+
+      def redis_key
+        "my_app_wechat_token_#{self.appid}"
       end
     end
   end
@@ -19,11 +25,17 @@ module Wechat
   module Ticket
     class JsapiBase
       def read_ticket
-        JSON.parse(Wechat.redis.get('my_app_wechat_ticket'))
+        JSON.parse(Wechat.redis.get(redis_key))
       end
 
       def write_ticket(ticket_hash)
-        Wechat.redis.set 'my_app_wechat_ticket', ticket_hash.to_json
+        Wechat.redis.set redis_key, ticket_hash.to_json
+      end
+
+      private
+
+      def redis_key
+        "my_app_wechat_ticket_#{self.appid}"
       end
     end
   end

--- a/lib/generators/wechat/templates/config/initializers/wechat_redis_store.rb
+++ b/lib/generators/wechat/templates/config/initializers/wechat_redis_store.rb
@@ -7,7 +7,7 @@ module Wechat
   module Token
     class AccessTokenBase
       def read_token
-        JSON.parse(Wechat.redis.get(redis_key))
+        JSON.parse(Wechat.redis.get(redis_key)) || {}
       end
 
       def write_token(token_hash)
@@ -25,7 +25,7 @@ module Wechat
   module Ticket
     class JsapiBase
       def read_ticket
-        JSON.parse(Wechat.redis.get(redis_key))
+        JSON.parse(Wechat.redis.get(redis_key))  || {}
       end
 
       def write_ticket(ticket_hash)

--- a/lib/generators/wechat/templates/config/wechat.yml
+++ b/lib/generators/wechat/templates/config/wechat.yml
@@ -33,3 +33,40 @@ development:
 
 test:
   <<: *default
+
+# Multiple Accounts
+#
+# wx2_development:
+#  <<: *default
+#  appid: "my_appid"
+#  secret: "my_secret"
+#  access_token: "tmp/wechat_access_token2"
+#  jsapi_ticket: "tmp/wechat_jsapi_ticket2"
+#
+# wx2_test:
+#  <<: *default
+#  appid: "my_appid"
+#  secret: "my_secret"
+#
+# wx2_production:
+#  <<: *default
+#  appid: "my_appid"
+#  secret: "my_secret"
+#
+# wx3_development:
+#  <<: *default
+#  appid: "my_appid"
+#  secret: "my_secret"
+#  access_token: "tmp/wechat_access_token3"
+#  jsapi_ticket: "tmp/wechat_jsapi_ticket3"
+#
+# wx3_test:
+#  <<: *default
+#  appid: "my_appid"
+#  secret: "my_secret"
+#
+# wx3_production:
+#  <<: *default
+#  appid: "my_appid"
+#  secret: "my_secret"
+#

--- a/lib/wechat.rb
+++ b/lib/wechat.rb
@@ -19,12 +19,13 @@ module Wechat
     end
   end
 
-  def self.config
-    ApiLoader.config
+  def self.config(account = :default)
+    ApiLoader.config(account)
   end
 
-  def self.api
-    @wechat_api ||= ApiLoader.with({})
+  def self.api(account = :default)
+    @wechat_apis ||= {}
+    @wechat_apis[account.to_sym] ||= ApiLoader.with({account: account})
   end
 end
 

--- a/lib/wechat/api_loader.rb
+++ b/lib/wechat/api_loader.rb
@@ -31,6 +31,13 @@ HELP
       configs = config_from_file || config_from_environment
 
       configs.symbolize_keys!
+      configs.each do |key, cfg|
+        if cfg.is_a?(Hash)
+          cfg.symbolize_keys!
+        else
+          raise "wrong wechat configuration format for #{key}"
+        end
+      end
 
       if defined?(::Rails)
         configs.each do |_, cfg|

--- a/lib/wechat/api_loader.rb
+++ b/lib/wechat/api_loader.rb
@@ -1,7 +1,8 @@
 module Wechat
   module ApiLoader
     def self.with(options)
-      c = ApiLoader.config
+      account = options[:account] || :default
+      c = ApiLoader.config(account)
 
       token_file = options[:token_file] || c.access_token || '/var/tmp/wechat_access_token'
       js_token_file = options[:js_token_file] || c.jsapi_ticket || '/var/tmp/wechat_jsapi_ticket'
@@ -19,50 +20,83 @@ HELP
       end
     end
 
-    @config = nil
+    @configs = nil
 
-    def self.config
-      return @config unless @config.nil?
-      @config ||= loading_config!
-      @config
+    def self.config(account = :default)
+      return @configs[account.to_sym] unless @configs.nil?
+      @configs ||= loading_config!
+      @configs[account.to_sym]
     end
 
     private_class_method def self.loading_config!
-      config ||= config_from_file || config_from_environment
+      configs ||= config_from_file || config_from_environment
+
+      configs.symbolize_keys!
 
       if defined?(::Rails)
-        config[:access_token] ||= Rails.root.join('tmp/access_token').to_s
-        config[:jsapi_ticket] ||= Rails.root.join('tmp/jsapi_ticket').to_s
+        configs.each do |_, cfg|
+          cfg[:access_token] ||= Rails.root.join('tmp/access_token').to_s
+          cfg[:jsapi_ticket] ||= Rails.root.join('tmp/jsapi_ticket').to_s
+        end
       end
-      config[:timeout] ||= 20
-      config[:have_session_class] = class_exists?('WechatSession')
-      config.symbolize_keys!
-      @config = OpenStruct.new(config)
+
+      configs.each do |_, cfg|
+        cfg[:timeout] ||= 20
+        cfg[:have_session_class] = class_exists?('WechatSession')
+      end
+
+      # create config object using raw config data
+      cfg_objs = {}
+      configs.each do |account, cfg|
+        cfg_objs[account] = OpenStruct.new(cfg)
+      end
+      cfg_objs
     end
 
     private_class_method def self.config_from_file
       if defined?(::Rails)
         config_file = Rails.root.join('config/wechat.yml')
-        return YAML.load(ERB.new(File.read(config_file)).result)[Rails.env] if File.exist?(config_file)
+        return resovle_config_file(config_file, Rails.env.to_s)
       else
         rails_config_file = File.join(Dir.getwd, 'config/wechat.yml')
         home_config_file = File.join(Dir.home, '.wechat.yml')
         if File.exist?(rails_config_file)
           rails_env = ENV['RAILS_ENV'] || 'default'
-          config = YAML.load(ERB.new(File.read(rails_config_file)).result)[rails_env]
-          if config.present? && (config['appid'] || config['corpid'])
+          config = resovle_config_file(rails_config_file, rails_env)
+          if config.present? && (default = config[:default])  && (default['appid'] || default['corpid'])
             puts "Using rails project config/wechat.yml #{rails_env} setting..."
             return config
           end
         end
         if File.exist?(home_config_file)
-          return YAML.load ERB.new(File.read(home_config_file)).result
+          # Causion:
+          # .wechat.yml and config/wechat.yml are the same format and rule now.
+          # It supports env and multiple accounts also.
+          # Old .wechat.yml maybe not work.
+
+          rails_env = ENV['RAILS_ENV'] || 'default'
+          return resovle_config_file(rails_config_file, rails_env)
         end
       end
     end
 
+    private_class_method def self.resovle_config_file(config_file, env)
+      if File.exist?(config_file)
+        raw_data = YAML.load(ERB.new(File.read(config_file)).result)
+        config = {}
+        raw_data.each do |key, value|
+          if key == env
+            configs[:default] = value
+          elsif m = /(.*?)_#{env}$/.match(key)
+            configs[m[1].to_sym] = value
+          end
+        end
+        config
+      end
+    end
+
     private_class_method def self.config_from_environment
-      { appid: ENV['WECHAT_APPID'],
+      value = { appid: ENV['WECHAT_APPID'],
         secret: ENV['WECHAT_SECRET'],
         corpid: ENV['WECHAT_CORPID'],
         corpsecret: ENV['WECHAT_CORPSECRET'],
@@ -75,6 +109,7 @@ HELP
         encoding_aes_key: ENV['WECHAT_ENCODING_AES_KEY'],
         jsapi_ticket: ENV['WECHAT_JSAPI_TICKET'],
         trusted_domain_fullname: ENV['WECHAT_TRUSTED_DOMAIN_FULLNAME'] }
+      {default: value}
     end
 
     private_class_method def self.class_exists?(class_name)

--- a/spec/dummy/config/dummy_wechat.yml
+++ b/spec/dummy/config/dummy_wechat.yml
@@ -1,0 +1,29 @@
+default: &default
+  appid: "my_appid"
+  secret: "my_secret"
+  token:    "my_token"
+  access_token: "C:/Users/[username]/wechat_access_token"
+  encrypt_mode: false # if true must fill encoding_aes_key
+  encoding_aes_key:  "my_encoding_aes_key"
+  jsapi_ticket: "C:/Users/[user_name]/wechat_jsapi_ticket"
+
+development:
+  <<: *default
+  trusted_domain_fullname: "http://your_dev.proxy.qqbrowser.cc"
+
+test:
+  <<: *default
+
+# Multiple Accounts
+#
+wx2_development:
+ <<: *default
+ appid: "my_appid2"
+ secret: "my_secret2"
+ access_token: "tmp/wechat_access_token2"
+ jsapi_ticket: "tmp/wechat_jsapi_ticket2"
+
+wx2_test:
+ <<: *default
+ appid: "my_appid2"
+ secret: "my_secret2"

--- a/spec/lib/wechat/api_loader_spec.rb
+++ b/spec/lib/wechat/api_loader_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe Wechat::ApiLoader do
+  it 'should config' do
+    expect(Wechat.config.token).to eq 'token'
+  end
+end

--- a/spec/lib/wechat/api_loader_spec.rb
+++ b/spec/lib/wechat/api_loader_spec.rb
@@ -1,7 +1,45 @@
 require 'spec_helper'
 
 RSpec.describe Wechat::ApiLoader do
+
   it 'should config' do
     expect(Wechat.config.token).to eq 'token'
+    expect(Wechat.config(:default).token).to eq 'token'
+  end
+
+  it 'should load config file' do
+    clear_wechat_configs
+    ENV['WECHAT_CONF_FILE'] = File.join(Dir.getwd, 'spec/dummy/config/dummy_wechat.yml')
+
+    expect(Wechat.config.appid).to eq 'my_appid'
+    expect(Wechat.config.secret).to eq 'my_secret'
+    expect(Wechat.config(:default).appid).to eq 'my_appid'
+    expect(Wechat.config(:default).secret).to eq 'my_secret'
+
+    expect(Wechat.config(:wx2).appid).to eq 'my_appid2'
+    expect(Wechat.config(:wx2).secret).to eq 'my_secret2'
+
+    clear_wechat_configs
+    ENV['WECHAT_CONF_FILE'] = nil
+  end
+
+  it 'should create api for account' do
+    clear_wechat_configs
+    ENV['WECHAT_CONF_FILE'] = File.join(Dir.getwd, 'spec/dummy/config/dummy_wechat.yml')
+
+    default_api = Wechat::ApiLoader.with({})
+    expect(default_api.access_token.appid).to eq 'my_appid'
+
+    new_api = Wechat::ApiLoader.with account: :wx2, token: 'new_token2'
+    expect(new_api.access_token.appid).to eq 'my_appid2'
+
+    clear_wechat_configs
+    ENV['WECHAT_CONF_FILE'] = nil
+  end
+
+  def clear_wechat_configs
+    Wechat::ApiLoader.class_eval do
+      @configs = nil
+    end
   end
 end


### PR DESCRIPTION
**完整支持多微信公众号**
原先版本可在声明 wechat_responder 时通过指定参数有限度支持多个微信公众号，其它地方并不支持，比如 Wechat.api 和 wechat 命令行工具并不支持，现在增加完整的多微信公众号支持特性。

**使用方法**
1.配置文件可增加多个公众号配置，用法类似 Rails 中 database.yml 多数据库配置的处理
development, test, production 段是默认公众号配置
[account_env] 是额外公众号配置，如
wx007_development, wx007_test, wx007_production 增加了 wx007 这个公众号的相关配置。

2.wechat_responder 声明
`wechat_responder account: :wx007`

3.wechat api 使用
Wechat.api(:wx007)  表示使用 wx007 这个公众号的 api
Wechat.api 和 Wechat.api(:default) 表示默认的 api

4.wechat 命令行使用
增加可选参数 -a, [--account=ACCOUNT]
如 ` wechat users -a wx007` 表示列举 wx007 这个公众号的粉丝列表

**实现原理**
关键处理
1.扩展配置文件规则和加载处理，通过 公众号 <-> 配置 的 hash 对象存储多个公众号配置
2.扩展 Wechat.config Wechat.api Wechat::ApiLoader.config 和 Wechat::ApiLoader.with 方法，
允许获取指定公众号的 config 和 api。

