### PR TITLE
解决模板Key有大写时显示不出来数据的bug

### DIFF
--- a/lib/wechat/message.rb
+++ b/lib/wechat/message.rb
@@ -131,7 +131,7 @@ module Wechat
     end
 
     def template(opts = {})
-      template_fields = camelize_hash_keys(opts.symbolize_keys.slice(:template_id, :topcolor, :url, :data))
+      template_fields = opts.symbolize_keys.slice(:template_id, :topcolor, :url, :data)
       update(MsgType: 'template', Template: template_fields)
     end
 
@@ -154,10 +154,9 @@ module Wechat
     def to_json
       json_hash = deep_recursive(message_hash) do |key, value|
         key = key.to_s
-        [(TO_JSON_KEY_MAP[key] || key.downcase), value]
+        [(TO_JSON_KEY_MAP[key] || key), value]
       end
-
-      json_hash = json_hash.select { |k, _v| TO_JSON_ALLOWED.include? k }
+      json_hash = json_hash.transform_keys{ |key| key.downcase }.select { |k, _v| TO_JSON_ALLOWED.include? k }
       case json_hash['msgtype']
       when 'text'
         json_hash['text'] = { 'content' => json_hash.delete('content') }

--- a/lib/wechat/message.rb
+++ b/lib/wechat/message.rb
@@ -152,11 +152,20 @@ module Wechat
     TO_JSON_ALLOWED = %w(touser msgtype content image voice video file music news articles template agentid).freeze
 
     def to_json
-      json_hash = deep_recursive(message_hash) do |key, value|
-        key = key.to_s
-        [(TO_JSON_KEY_MAP[key] || key), value]
+      if message_hash[:MsgType] == "template"
+        json_hash = deep_recursive(message_hash) do |key, value|
+          key = key.to_s
+          [(TO_JSON_KEY_MAP[key] || key), value]
+        end
+        json_hash = json_hash.transform_keys{ |key| key.downcase }.select { |k, _v| TO_JSON_ALLOWED.include? k }
+      else
+        json_hash = deep_recursive(message_hash) do |key, value|
+          key = key.to_s
+          [(TO_JSON_KEY_MAP[key] || key.downcase), value]
+        end
+        json_hash = json_hash.select { |k, _v| TO_JSON_ALLOWED.include? k }
       end
-      json_hash = json_hash.transform_keys{ |key| key.downcase }.select { |k, _v| TO_JSON_ALLOWED.include? k }
+      
       case json_hash['msgtype']
       when 'text'
         json_hash['text'] = { 'content' => json_hash.delete('content') }

--- a/spec/lib/wechat/message_spec.rb
+++ b/spec/lib/wechat/message_spec.rb
@@ -303,16 +303,24 @@ RSpec.describe Wechat::Message do
       end
 
       specify 'can convert template message' do
-        request = Wechat::Message.to('toUser')
-                                 .template(template_id: 'template_id', url: 'http://weixin.qq.com/download',
-                                           data: { first: { value: '恭喜你购买成功！' } })
+        request = Wechat::Message.to('toUser').template(template_id: 'template_id', 
+                                          url: 'http://weixin.qq.com/download',
+                                          data: { 
+                                            first: { value: "恭喜你购买成功！" }, 
+                                            orderProductName: { value: "巧克力" }, 
+                                            orderMoneySum: { value: "39.8元" }, 
+                                            Remark: { value: "欢迎再次购买！" }
+                                          })
 
         expect(request.to_json).to eq({
           touser: 'toUser',
           template_id: 'template_id',
           url: 'http://weixin.qq.com/download',
-          data: {
-            first: { value: '恭喜你购买成功！' }
+          data: { 
+            first: { value: "恭喜你购买成功！" }, 
+            orderProductName: { value: "巧克力" }, 
+            orderMoneySum: { value: "39.8元" }, 
+            Remark: { value: "欢迎再次购买！" }
           }
         }.to_json)
       end


### PR DESCRIPTION
fixes #157
1. 去掉了template里的 camelize_hash_keys方法，因为 camelize_hash_keys方法会将模板消息里的用户设定的key的大小写改变而无法复原；
2. to_json方法里,将json_hash的key变为小写，由于放在deep_recursive里，也会导致模板消息里的用户设定的key的大小写改变，所以提取出来，放在后面进行select之前执行。