### PR TITLE
Improve error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,17 +17,17 @@
 
 ## v0.8.4 (released at 1/12/2017)
 
-# Support Ruby 2.4.0 
-# Add support of Enterprise RedPacket API, by @zhangbin #169
+* Support Ruby 2.4.0
+* Add support of Enterprise RedPacket API, by @zhangbin #169
 
 ## v0.8.3 (released at 11/26/2016)
 
-# Fix wechat template key has camelCase problem, by @RyanChenDji #159
-# Fix long time of oauth2_state bug for wechat_oauth2 methods, by @IvanChou #162
+* Fix wechat template key has camelCase problem, by @RyanChenDji #159
+* Fix long time of oauth2_state bug for wechat_oauth2 methods, by @IvanChou #162
 
 ## v0.8.2 (released at 11/2/2016)
 
-# Bug which if not using multi-account but using web login.
+* Bug which if not using multi-account but using web login.
 
 ## v0.8.1 (released at 11/2/2016)
 
@@ -57,7 +57,7 @@
 
 ## v0.7.17 (released at 8/18/2016)
 
-* Allow declare wechat_api at ApplicationController, but using wechat at sub controller. #104 
+* Allow declare wechat_api at ApplicationController, but using wechat at sub controller. #104
 
 ## v0.7.16 (released at 7/27/2016)
 
@@ -135,9 +135,9 @@
 * Optional session support by @zfben #81, #88, #91
 * Replace after_wechat_response with Rails Nofications facility, by @zfben, original issue is #79
 * New user_batchget API. #89
-* Support Rails 3.2 again after support Rails 5.0. by @guange2015 #87 
+* Support Rails 3.2 again after support Rails 5.0. by @guange2015 #87
 * Fetch setting from RAILS_ENV first, then fetch default. by @kikyous #85
-* Warning not support on :scan with regular expression, reason see #84 
+* Warning not support on :scan with regular expression, reason see #84
 
 ## v0.7.1 (released at 1/11/2016)
 
@@ -151,9 +151,9 @@
 
 ## v0.6.10 (released at 1/17/2016)
 
-* Support Rails 3.2 again after support Rails 5.0. by @guange2015 #87 
+* Support Rails 3.2 again after support Rails 5.0. by @guange2015 #87
 * Fetch setting from RAILS_ENV first, then fetch default. by @kikyous #85
-* Warning not support on :scan with regular expression. by @kikyous #84 
+* Warning not support on :scan with regular expression. by @kikyous #84
 
 ## v0.6.9 (released at 1/6/2016)
 
@@ -213,7 +213,7 @@
 * Scan 2D barcode using new syntax `on :scan, with: 'BINDING_QR_CODE' ` instead of `on :event, with: 'BINDING_QR_CODE' ` in previous version #55
   Which will fix can not using `on :event, with: "scan" ` problem
 * Batch job using new syntax `on :batch_job, with: 'replace_user' `
-instead of previous `on :event, with: 'replace_user' `. 
+instead of previous `on :event, with: 'replace_user' `.
 * Click menu support new syntax `on :click, with: 'BOOK_LUNCH' `, but `on :event, with: 'BOOK_LUNCH' ` still supported. perfer `on :click` because it running faster and more nature expression.
 * Wechat::Responder using Hash for new :client and :batch_job event, avoid time consuming Array match responder
 * Fix refresh token not working problem under ruby 2.0.0 #54
@@ -232,7 +232,7 @@ instead of previous `on :event, with: 'replace_user' `.
 
 * Fix wrong number of arguments at Wechat::Responder.on by using arity #47
 * Fix can not access wechat method after using instance level context.
-* Fix skip_verify_ssl parameter error. 
+* Fix skip_verify_ssl parameter error.
 
 ## v0.4.1 (released at 9/6/2015)
 

--- a/lib/wechat.rb
+++ b/lib/wechat.rb
@@ -11,6 +11,7 @@ module Wechat
   autoload :ControllerApi, 'wechat/controller_api'
 
   class AccessTokenExpiredError < StandardError; end
+  class InvalidCredentialError < StandardError; end
   class ResponseError < StandardError
     attr_reader :error_code
     def initialize(errcode, errmsg)

--- a/lib/wechat/http_client.rb
+++ b/lib/wechat/http_client.rb
@@ -70,6 +70,8 @@ module Wechat
       parse_as = {
         %r{^application\/json} => :json,
         %r{^image\/.*}         => :file,
+        %r{^audio\/.*}         => :file,
+        %r{^voice\/.*}         => :file,
         %r{^text\/html}        => :xml,
         %r{^text\/plain}       => :probably_json
       }.each_with_object([]) { |match, memo| memo << match[1] if content_type =~ match[0] }.first || as || :text

--- a/lib/wechat/token/access_token_base.rb
+++ b/lib/wechat/token/access_token_base.rb
@@ -30,6 +30,8 @@ module Wechat
       end
 
       def write_token_to_store(token_hash)
+        raise InvalidCredentialError unless token_hash.is_a?(Hash) && token_hash['access_token']
+
         token_hash['got_token_at'.freeze] = Time.now.to_i
         token_hash['token_expires_in'.freeze] = token_hash.delete('expires_in')
         write_token(token_hash)

--- a/spec/lib/wechat/corp_access_token_spec.rb
+++ b/spec/lib/wechat/corp_access_token_spec.rb
@@ -35,7 +35,15 @@ RSpec.describe Wechat::Token::CorpAccessToken do
     specify "won't set access_token if response value invalid" do
       allow(client).to receive(:get).and_return('rubbish')
 
-      expect { subject.refresh }.to raise_error
+      expect { subject.refresh }.to raise_error(Wechat::InvalidCredentialError)
+      expect(subject.access_token).to be_nil
+    end
+
+    # it will be nil(content_length 0) if appid and secret is invalid
+    specify "won't set access_token if response value is nil" do
+      allow(client).to receive(:get).and_return(nil)
+
+      expect { subject.refresh }.to raise_error(Wechat::InvalidCredentialError)
       expect(subject.access_token).to be_nil
     end
   end

--- a/spec/lib/wechat/http_client_spec.rb
+++ b/spec/lib/wechat/http_client_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe Wechat::HttpClient do
     double 'json', response_params.merge(body: { result: 'success' }.to_json,
                                          headers: { content_type: 'application/json' })
   end
+  let(:response_json_as_text_plain) do
+    double 'json', response_params.merge(body: { result: 'success' }.to_json)
+  end
   let(:response_xml) do
     double 'xml', response_params.merge(body: '<xml><result_code>SUCCESS</result_code></xml>',
                                         headers: { content_type: 'text/html' })
@@ -88,9 +91,35 @@ RSpec.describe Wechat::HttpClient do
         expect(subject.send(:request, 'image') { response_image }).to be_a(Tempfile)
       end
 
+      specify 'will return response body as file for audio' do
+        response_audio = double 'audio', response_params.merge(body: 'stream', headers: { content_type: 'audio/amr' })
+        expect(subject.send(:request, 'media') { response_audio }).to be_a(Tempfile)
+      end
+
+      specify 'will return response body as file for speex' do
+        response_speex = double 'speex', response_params.merge(body: 'stream', headers: { content_type: 'voice/speex' })
+        expect(subject.send(:request, 'media') { response_speex }).to be_a(Tempfile)
+      end
+
       specify 'will return response body as file for unknown content_type' do
         response_stream = double 'image', response_params.merge(body: 'stream', headers: { content_type: 'stream' })
         expect(subject.send(:request, 'image', as: :file) { response_stream }).to be_a(Tempfile)
+      end
+    end
+
+    context 'parse content_type of text/plain' do
+      specify 'will return response body as json for text/plain content_type' do
+        expect(subject.send(:request, 'json') { response_json_as_text_plain }).to be_a(Hash)
+      end
+
+      specify 'raise ResponseError given response has error json with content_type of text/plain' do
+        allow(response_json_as_text_plain).to receive(:body).and_return({ errcode: 40007, errmsg: 'invalid media_id' }.to_json)
+        expect { subject.send(:request, 'media', as: :file) { response_json_as_text_plain } }.to raise_error(Wechat::ResponseError)
+      end
+
+      specify 'will fallback to user-specified format for not json' do
+        allow(response_json_as_text_plain).to receive(:body).and_return('not a json string')
+        expect(subject.send(:request, 'media', as: :file) { response_json_as_text_plain }).to be_a(Tempfile)
       end
     end
 

--- a/spec/lib/wechat/public_access_token_spec.rb
+++ b/spec/lib/wechat/public_access_token_spec.rb
@@ -59,7 +59,15 @@ RSpec.describe Wechat::Token::PublicAccessToken do
     specify "won't set access_token if response value invalid" do
       allow(client).to receive(:get).and_return('rubbish')
 
-      expect { subject.refresh }.to raise_error
+      expect { subject.refresh }.to raise_error(Wechat::InvalidCredentialError)
+      expect(subject.access_token).to be_nil
+    end
+
+    # it will be nil(content_length 0) if appid and secret is invalid
+    specify "won't set access_token if response value is nil" do
+      allow(client).to receive(:get).and_return(nil)
+
+      expect { subject.refresh }.to raise_error(Wechat::InvalidCredentialError)
       expect(subject.access_token).to be_nil
     end
   end


### PR DESCRIPTION
## 对于无效的appid和secret

当用户设置的appid和secret无效时，微信会返回空响应。
```shell
curl -i 'https://api.weixin.qq.com/cgi-bin/token?grant_type=client_credential&appid=APPID&secret=APPSECRET'

HTTP/1.1 200 OK
Connection: keep-alive
Cache-Control: no-cache, must-revalidate
Content-Type: text/html; charset=gbk
Content-Length: 0
```

该PR对这种情况进行了处理，并抛出`InvalidCredentialError`。

## 识别`audio/amr`和`voice/speex`

对于上述两种`content-type`，识别为`:file`。

## 某些错误情况，微信会范围`json`格式，但`content-type`为`text/plain`

```shell
curl -i "https://api.weixin.qq.com/cgi-bin/media/get/jssdk?access_token=ACCESS_TOKEN&media_id=MEDIA_ID"

HTTP/1.1 200 OK
Connection: keep-alive
Content-Type: text/plain
Date: Fri, 07 Apr 2017 10:39:50 GMT
Content-Length: 68

{"errcode":40007,"errmsg":"invalid media_id hint: [2DlkvA0590e396]"}
```

该PR会尝试将响应转换为`json`，如果转换失败，使用用户指定的格式处理。