### PR TITLE
Feature/better multiple accounts support

### DIFF
--- a/lib/action_controller/wechat_responder.rb
+++ b/lib/action_controller/wechat_responder.rb
@@ -2,13 +2,15 @@ module ActionController
   module WechatResponder
     def wechat_api(opts = {})
       include Wechat::ControllerApi
-      self.wechat_cfg_account = opts[:account].present? ? opts[:account].to_sym : :default
+      account = opts.delete(:account)
+      self.wechat_cfg_account = account ? account.to_sym : :default
       self.wechat_api_client = load_controller_wechat(wechat_cfg_account, opts)
     end
 
     def wechat_responder(opts = {})
       include Wechat::Responder
-      self.wechat_cfg_account = opts[:account].present? ? opts[:account].to_sym : :default
+      account = opts.delete(:account)
+      self.wechat_cfg_account = account ? account.to_sym : :default
       self.wechat_api_client = load_controller_wechat(wechat_cfg_account, opts)
     end
 
@@ -34,7 +36,7 @@ module ActionController
       access_token = opts[:access_token] || cfg.access_token
       jsapi_ticket = opts[:jsapi_ticket] || cfg.jsapi_ticket
 
-      return self.wechat_api_client = Wechat.api if account == :default && opts.empty?
+      return Wechat.api if account == :default && opts.empty?
 
       if corpid.present?
         corpsecret = opts[:corpsecret] || cfg.corpsecret

--- a/lib/action_controller/wechat_responder.rb
+++ b/lib/action_controller/wechat_responder.rb
@@ -19,29 +19,29 @@ module ActionController
     private
 
     def load_controller_wechat(account, opts = {})
-      self.token = opts[:token] || Wechat.config(account).token
-      self.appid = opts[:appid] || Wechat.config(account).appid
-      self.corpid = opts[:corpid] || Wechat.config(account).corpid
-      self.agentid = opts[:agentid] || Wechat.config(account).agentid
-      self.encrypt_mode = opts[:encrypt_mode] || Wechat.config(account).encrypt_mode || corpid.present?
+      cfg = Wechat.config(account)
+      self.token = opts[:token] || cfg.token
+      self.appid = opts[:appid] || cfg.appid
+      self.corpid = opts[:corpid] || cfg.corpid
+      self.agentid = opts[:agentid] || cfg.agentid
+      self.encrypt_mode = opts[:encrypt_mode] || cfg.encrypt_mode || corpid.present?
       self.timeout = opts[:timeout] || 20
       self.skip_verify_ssl = opts[:skip_verify_ssl]
-      self.encoding_aes_key = opts[:encoding_aes_key] || Wechat.config(account).encoding_aes_key
-      self.trusted_domain_fullname = opts[:trusted_domain_fullname] || Wechat.config(account).trusted_domain_fullname
-      Wechat.config(account).oauth2_cookie_duration ||= 1.hour
-      self.oauth2_cookie_duration = opts[:oauth2_cookie_duration] || Wechat.config(account).oauth2_cookie_duration.to_i.seconds
+      self.encoding_aes_key = opts[:encoding_aes_key] || cfg.encoding_aes_key
+      self.trusted_domain_fullname = opts[:trusted_domain_fullname] || cfg.trusted_domain_fullname
+      self.oauth2_cookie_duration = opts[:oauth2_cookie_duration] || cfg.oauth2_cookie_duration.to_i.seconds
 
-      access_token = opts[:access_token] || Wechat.config(account).access_token
-      jsapi_ticket = opts[:jsapi_ticket] || Wechat.config(account).jsapi_ticket
+      access_token = opts[:access_token] || cfg.access_token
+      jsapi_ticket = opts[:jsapi_ticket] || cfg.jsapi_ticket
 
       return self.wechat_api_client = Wechat.api if account == :default && opts.empty?
 
       if corpid.present?
-        corpsecret = opts[:corpsecret] || Wechat.config(account).corpsecret
+        corpsecret = opts[:corpsecret] || cfg.corpsecret
         Wechat::CorpApi.new(corpid, corpsecret, access_token, \
                             agentid, timeout, skip_verify_ssl, jsapi_ticket)
       else
-        secret = opts[:secret] || Wechat.config(account).secret
+        secret = opts[:secret] || cfg.secret
         Wechat::Api.new(appid, secret, access_token, \
                         timeout, skip_verify_ssl, jsapi_ticket)
       end

--- a/lib/action_controller/wechat_responder.rb
+++ b/lib/action_controller/wechat_responder.rb
@@ -14,8 +14,12 @@ module ActionController
       self.wechat_api_client = load_controller_wechat(wechat_cfg_account, opts)
     end
 
-    def wechat
-      self.wechat_api_client ||= load_controller_wechat(wechat_cfg_account)
+    def wechat(account = nil)
+      if account && account != wechat_cfg_account
+        Wechat.api(account)
+      else
+        self.wechat_api_client ||= load_controller_wechat(wechat_cfg_account)
+      end
     end
 
     private
@@ -27,16 +31,20 @@ module ActionController
       self.corpid = opts[:corpid] || cfg.corpid
       self.agentid = opts[:agentid] || cfg.agentid
       self.encrypt_mode = opts[:encrypt_mode] || cfg.encrypt_mode || corpid.present?
-      self.timeout = opts[:timeout] || 20
-      self.skip_verify_ssl = opts[:skip_verify_ssl]
       self.encoding_aes_key = opts[:encoding_aes_key] || cfg.encoding_aes_key
       self.trusted_domain_fullname = opts[:trusted_domain_fullname] || cfg.trusted_domain_fullname
       self.oauth2_cookie_duration = opts[:oauth2_cookie_duration] || cfg.oauth2_cookie_duration.to_i.seconds
+      self.timeout = opts[:timeout] || cfg.timeout
+      if opts.key?(:skip_verify_ssl)
+        self.skip_verify_ssl = opts[:skip_verify_ssl]
+      else
+        self.skip_verify_ssl = cfg.skip_verify_ssl
+      end
+
+      return Wechat.api if account == :default && opts.empty?
 
       access_token = opts[:access_token] || cfg.access_token
       jsapi_ticket = opts[:jsapi_ticket] || cfg.jsapi_ticket
-
-      return Wechat.api if account == :default && opts.empty?
 
       if corpid.present?
         corpsecret = opts[:corpsecret] || cfg.corpsecret

--- a/lib/generators/wechat/templates/config/initializers/wechat_redis_store.rb
+++ b/lib/generators/wechat/templates/config/initializers/wechat_redis_store.rb
@@ -35,7 +35,7 @@ module Wechat
       private
 
       def redis_key
-        "my_app_wechat_ticket_#{self.appid}"
+        "my_app_wechat_ticket_#{self.access_token.appid}"
       end
     end
   end

--- a/lib/wechat/api_loader.rb
+++ b/lib/wechat/api_loader.rb
@@ -46,6 +46,7 @@ module Wechat
       configs.each do |_, cfg|
         cfg[:timeout] ||= 20
         cfg[:have_session_class] = class_exists?('WechatSession')
+        cfg[:oauth2_cookie_duration] ||= 1.hour
       end
 
       # create config object using raw config data

--- a/lib/wechat/api_loader.rb
+++ b/lib/wechat/api_loader.rb
@@ -4,8 +4,8 @@ module Wechat
       account = options[:account] || :default
       c = ApiLoader.config(account)
 
-      token_file = options[:token_file] || c.access_token || '/var/tmp/wechat_access_token'
-      js_token_file = options[:js_token_file] || c.jsapi_ticket || '/var/tmp/wechat_jsapi_ticket'
+      token_file = options[:token_file] || c.access_token.presence || '/var/tmp/wechat_access_token'
+      js_token_file = options[:js_token_file] || c.jsapi_ticket.presence || '/var/tmp/wechat_jsapi_ticket'
 
       if c.appid && c.secret && token_file.present?
         Wechat::Api.new(c.appid, c.secret, token_file, c.timeout, c.skip_verify_ssl, js_token_file)

--- a/lib/wechat/api_loader.rb
+++ b/lib/wechat/api_loader.rb
@@ -12,11 +12,7 @@ module Wechat
       elsif c.corpid && c.corpsecret && token_file.present?
         Wechat::CorpApi.new(c.corpid, c.corpsecret, token_file, c.agentid, c.timeout, c.skip_verify_ssl, js_token_file)
       else
-        puts <<-HELP
-Need create ~/.wechat.yml with wechat appid and secret
-or running at rails root folder so wechat can read config/wechat.yml
-HELP
-        exit 1
+        raise "Need create ~/.wechat.yml with wechat appid and secret or running at rails root folder so wechat can read config/wechat.yml"
       end
     end
 

--- a/lib/wechat/controller_api.rb
+++ b/lib/wechat/controller_api.rb
@@ -9,11 +9,7 @@ module Wechat
 
     def wechat(account = nil)
       # Make sure user can continue access wechat at instance level similar to class level
-      if account
-        Wechat.api(account)
-      else
-        self.class.wechat
-      end
+      self.class.wechat(account)
     end
 
     def wechat_oauth2(scope = 'snsapi_base', page_url = nil, account = nil, &block)

--- a/lib/wechat/controller_api.rb
+++ b/lib/wechat/controller_api.rb
@@ -17,6 +17,9 @@ module Wechat
     end
 
     def wechat_oauth2(scope = 'snsapi_base', page_url = nil, account = nil, &block)
+      # ensure wechat initialization
+      self.class.corpid || self.class.appid || self.class.wechat
+
       api = wechat(account)
       if account
         config = Wechat.config(account)

--- a/lib/wechat/controller_api.rb
+++ b/lib/wechat/controller_api.rb
@@ -7,40 +7,51 @@ module Wechat
                     :skip_verify_ssl, :encoding_aes_key, :trusted_domain_fullname, :oauth2_cookie_duration
     end
 
-    def wechat
-      self.class.wechat # Make sure user can continue access wechat at instance level similar to class level
+    def wechat(account = nil)
+      # Make sure user can continue access wechat at instance level similar to class level
+      if account
+        Wechat.api(account)
+      else
+        self.class.wechat
+      end
     end
 
-    def wechat_oauth2(scope = 'snsapi_base', page_url = nil, &block)
-      appid = self.class.corpid || self.class.appid || lambda do
-        self.class.wechat # to initialize wechat_api_client at first time call wechat_oauth2
-        self.class.corpid || self.class.appid
-      end.call
+    def wechat_oauth2(scope = 'snsapi_base', page_url = nil, account = nil, &block)
+      api = wechat(account)
+      if account
+        config = Wechat.config(account)
+        appid = config.corpid || config.appid
+        is_crop_account = !!config.corpid
+      else
+        appid = self.class.corpid || self.class.appid
+        is_crop_account = !!self.class.corpid
+      end
+
       raise 'Can not get corpid or appid, so please configure it first to using wechat_oauth2' if appid.blank?
 
-      wechat.jsapi_ticket.ticket if wechat.jsapi_ticket.oauth2_state.nil?
+      api.jsapi_ticket.ticket if api.jsapi_ticket.oauth2_state.nil?
       oauth2_params = {
         appid: appid,
-        redirect_uri: page_url,
+        redirect_uri: page_url || generate_redirect_uri(account),
         scope: scope,
         response_type: 'code',
-        state: wechat.jsapi_ticket.oauth2_state
+        state: api.jsapi_ticket.oauth2_state
       }
 
       return generate_oauth2_url(oauth2_params) unless block_given?
-      self.class.corpid ? wechat_corp_oauth2(oauth2_params, &block) : wechat_public_oauth2(oauth2_params, &block)
+      is_crop_account ? wechat_corp_oauth2(oauth2_params, account, &block) : wechat_public_oauth2(oauth2_params, account, &block)
     end
 
     private
 
-    def wechat_public_oauth2(oauth2_params)
+    def wechat_public_oauth2(oauth2_params, account = nil)
       openid  = cookies.signed_or_encrypted[:we_openid]
       unionid = cookies.signed_or_encrypted[:we_unionid]
       we_token = cookies.signed_or_encrypted[:we_access_token]
       if openid.present?
         yield openid, { 'openid' => openid, 'unionid' => unionid, 'access_token' => we_token}
       elsif params[:code].present? && params[:state] == oauth2_params[:state]
-        access_info = wechat.web_access_token(params[:code])
+        access_info = wechat(account).web_access_token(params[:code])
         cookies.signed_or_encrypted[:we_openid] = { value: access_info['openid'], expires: self.class.oauth2_cookie_duration.from_now }
         cookies.signed_or_encrypted[:we_unionid] = { value: access_info['unionid'], expires: self.class.oauth2_cookie_duration.from_now }
         cookies.signed_or_encrypted[:we_access_token] = { value: access_info['access_token'], expires: self.class.oauth2_cookie_duration.from_now }
@@ -50,13 +61,13 @@ module Wechat
       end
     end
 
-    def wechat_corp_oauth2(oauth2_params)
+    def wechat_corp_oauth2(oauth2_params, account = nil)
       userid   = cookies.signed_or_encrypted[:we_userid]
       deviceid = cookies.signed_or_encrypted[:we_deviceid]
       if userid.present? && deviceid.present?
         yield userid, { 'UserId' => userid, 'DeviceId' => deviceid }
       elsif params[:code].present? && params[:state] == oauth2_params[:state]
-        userinfo = wechat.getuserinfo(params[:code])
+        userinfo = wechat(account).getuserinfo(params[:code])
         cookies.signed_or_encrypted[:we_userid] = { value: userinfo['UserId'], expires: self.class.oauth2_cookie_duration.from_now }
         cookies.signed_or_encrypted[:we_deviceid] = { value: userinfo['DeviceId'], expires: self.class.oauth2_cookie_duration.from_now }
         yield userinfo['UserId'], userinfo
@@ -65,13 +76,18 @@ module Wechat
       end
     end
 
-    def generate_oauth2_url(oauth2_params)
-      if oauth2_params[:redirect_uri].blank?
-        page_url = (td = self.class.trusted_domain_fullname) ? "#{td}#{request.original_fullpath}" : request.original_url
-        safe_query = request.query_parameters.reject { |k, _| %w(code state access_token).include? k }.to_query
-        oauth2_params[:redirect_uri] = page_url.sub(request.query_string, safe_query)
+    def generate_redirect_uri(account = nil)
+      domain_name = if account
+        Wechat.config(account).trusted_domain_fullname
+      else
+        self.class.trusted_domain_fullname
       end
+      page_url = domain_name ? "#{domain_name}#{request.original_fullpath}" : request.original_url
+      safe_query = request.query_parameters.reject { |k, _| %w(code state access_token).include? k }.to_query
+      page_url.sub(request.query_string, safe_query)
+    end
 
+    def generate_oauth2_url(oauth2_params)
       if oauth2_params[:scope] == 'snsapi_login'
         "https://open.weixin.qq.com/connect/qrconnect?#{oauth2_params.to_query}#wechat_redirect"
       else

--- a/lib/wechat/helpers.rb
+++ b/lib/wechat/helpers.rb
@@ -1,16 +1,33 @@
 module Wechat
   module Helpers
     def wechat_config_js(config_options = {})
-      page_url = if controller.class.trusted_domain_fullname
-                   "#{controller.class.trusted_domain_fullname}#{controller.request.original_fullpath}"
+      account = config_options[:account]
+
+      # Get domain_name, api and app_id
+      if account.blank? || account == controller.class.wechat_cfg_account
+        # default account
+        domain_name = controller.class.trusted_domain_fullname
+        api = controller.wechat
+        app_id = controller.class.corpid || controller.class.appid
+      else
+        # not default account
+        config = Wechat.config(account)
+        domain_name = config.trusted_domain_fullname
+        api = Wechat.api(account)
+        app_id = config.corpid || config.appid
+      end
+
+      page_url = if domain_name
+                   "#{domain_name}#{controller.request.original_fullpath}"
                  else
                    controller.request.original_url
                  end
-      js_hash = controller.wechat.jsapi_ticket.signature(page_url)
+      js_hash = api.jsapi_ticket.signature(page_url)
+
       config_js = <<-WECHAT_CONFIG_JS
 wx.config({
   debug: #{config_options[:debug]},
-  appId: "#{controller.class.corpid || controller.class.appid}",
+  appId: "#{app_id}",
   timestamp: "#{js_hash[:timestamp]}",
   nonceStr: "#{js_hash[:noncestr]}",
   signature: "#{js_hash[:signature]}",

--- a/lib/wechat/helpers.rb
+++ b/lib/wechat/helpers.rb
@@ -13,7 +13,7 @@ module Wechat
         # not default account
         config = Wechat.config(account)
         domain_name = config.trusted_domain_fullname
-        api = Wechat.api(account)
+        api = controller.wechat(account)
         app_id = config.corpid || config.appid
       end
 

--- a/spec/lib/wechat/api_loader_spec.rb
+++ b/spec/lib/wechat/api_loader_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe Wechat::ApiLoader do
 
   describe "should support multiple accounts config" do
     before(:all) do
-      clear_wechat_configs
+      Wechat::ApiLoader.class_eval { @configs = nil }
       ENV['WECHAT_CONF_FILE'] = File.join(Dir.getwd, 'spec/dummy/config/dummy_wechat.yml')
     end
 
     after(:all) do
-      clear_wechat_configs
+      Wechat::ApiLoader.class_eval { @configs = nil }
       ENV['WECHAT_CONF_FILE'] = nil
     end
 
@@ -34,12 +34,6 @@ RSpec.describe Wechat::ApiLoader do
 
       new_api = Wechat::ApiLoader.with account: :wx2, token: 'new_token2'
       expect(new_api.access_token.appid).to eq 'my_appid2'
-    end
-  end
-
-  def clear_wechat_configs
-    Wechat::ApiLoader.class_eval do
-      @configs = nil
     end
   end
 end

--- a/spec/lib/wechat/api_loader_spec.rb
+++ b/spec/lib/wechat/api_loader_spec.rb
@@ -7,34 +7,34 @@ RSpec.describe Wechat::ApiLoader do
     expect(Wechat.config(:default).token).to eq 'token'
   end
 
-  it 'should load config file' do
-    clear_wechat_configs
-    ENV['WECHAT_CONF_FILE'] = File.join(Dir.getwd, 'spec/dummy/config/dummy_wechat.yml')
+  describe "should support multiple accounts config" do
+    before(:all) do
+      clear_wechat_configs
+      ENV['WECHAT_CONF_FILE'] = File.join(Dir.getwd, 'spec/dummy/config/dummy_wechat.yml')
+    end
 
-    expect(Wechat.config.appid).to eq 'my_appid'
-    expect(Wechat.config.secret).to eq 'my_secret'
-    expect(Wechat.config(:default).appid).to eq 'my_appid'
-    expect(Wechat.config(:default).secret).to eq 'my_secret'
+    after(:all) do
+      clear_wechat_configs
+      ENV['WECHAT_CONF_FILE'] = nil
+    end
 
-    expect(Wechat.config(:wx2).appid).to eq 'my_appid2'
-    expect(Wechat.config(:wx2).secret).to eq 'my_secret2'
+    it 'should load config file' do
+      expect(Wechat.config.appid).to eq 'my_appid'
+      expect(Wechat.config.secret).to eq 'my_secret'
+      expect(Wechat.config(:default).appid).to eq 'my_appid'
+      expect(Wechat.config(:default).secret).to eq 'my_secret'
 
-    clear_wechat_configs
-    ENV['WECHAT_CONF_FILE'] = nil
-  end
+      expect(Wechat.config(:wx2).appid).to eq 'my_appid2'
+      expect(Wechat.config(:wx2).secret).to eq 'my_secret2'
+    end
 
-  it 'should create api for account' do
-    clear_wechat_configs
-    ENV['WECHAT_CONF_FILE'] = File.join(Dir.getwd, 'spec/dummy/config/dummy_wechat.yml')
+    it 'should create api for account' do
+      default_api = Wechat::ApiLoader.with({})
+      expect(default_api.access_token.appid).to eq 'my_appid'
 
-    default_api = Wechat::ApiLoader.with({})
-    expect(default_api.access_token.appid).to eq 'my_appid'
-
-    new_api = Wechat::ApiLoader.with account: :wx2, token: 'new_token2'
-    expect(new_api.access_token.appid).to eq 'my_appid2'
-
-    clear_wechat_configs
-    ENV['WECHAT_CONF_FILE'] = nil
+      new_api = Wechat::ApiLoader.with account: :wx2, token: 'new_token2'
+      expect(new_api.access_token.appid).to eq 'my_appid2'
+    end
   end
 
   def clear_wechat_configs

--- a/spec/lib/wechat/helpers_spec.rb
+++ b/spec/lib/wechat/helpers_spec.rb
@@ -25,12 +25,12 @@ RSpec.describe WechatApiController, type: :controller do
 
   describe '#wechat_config_js with account' do
     before(:all) do
-      clear_wechat_configs
+      Wechat::ApiLoader.class_eval { @configs = nil }
       ENV['WECHAT_CONF_FILE'] = File.join(Dir.getwd, 'spec/dummy/config/dummy_wechat.yml')
     end
 
     after(:all) do
-      clear_wechat_configs
+      Wechat::ApiLoader.class_eval { @configs = nil }
       ENV['WECHAT_CONF_FILE'] = nil
     end
 
@@ -61,9 +61,4 @@ RSpec.describe WechatApiController, type: :controller do
     end
   end
 
-  def clear_wechat_configs
-    Wechat::ApiLoader.class_eval do
-      @configs = nil
-    end
-  end
 end

--- a/spec/lib/wechat/helpers_spec.rb
+++ b/spec/lib/wechat/helpers_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe WechatApiController, type: :controller do
     end
 
     it '#wechat_config_js' do
-      controller.request = ActionController::TestRequest.create
+      controller.request = ActionController::TestRequest.create ActionController::TestRequest::DEFAULT_ENV
       controller.request.host = 'test.host'
       expect(controller.wechat.jsapi_ticket).to receive(:signature)
         .with('http://test.host').and_return(js_hash_result)
@@ -39,7 +39,7 @@ RSpec.describe WechatApiController, type: :controller do
     end
 
     it '#wechat_config_js' do
-      controller.request = ActionController::TestRequest.create
+      controller.request = ActionController::TestRequest.create ActionController::TestRequest::DEFAULT_ENV
       controller.request.host = 'test.host'
       expect(Wechat.api(:wx2).jsapi_ticket).to receive(:signature)
         .with('http://test.host').and_return(js_hash_result)
@@ -53,7 +53,7 @@ RSpec.describe WechatApiController, type: :controller do
     end
 
     it 'called with trusted_domain' do
-      controller.request = ActionController::TestRequest.create
+      controller.request = ActionController::TestRequest.create ActionController::TestRequest::DEFAULT_ENV
       controller.request.host = 'test.host'
       expect(controller.wechat.jsapi_ticket).to receive(:signature)
         .with('http://trusted.host').and_return(js_hash_result)


### PR DESCRIPTION
- 更好的多账户支持
  - wechat_config_js 支持多账户
  - wechat_oauth2 支持多账户
  - wechat 方法支持多账户

- 修正一些小 bug
  - wechat_redis_store template 中 ticket 的 appid 没有正确引用
  -  load_controller_wechat 中 oauth2_cookie_duration, timeout, skip_verify_ssl 没有取配置值