### PR TITLE
Hotfix/wrong oauth2 state

### DIFF
--- a/lib/wechat/controller_api.rb
+++ b/lib/wechat/controller_api.rb
@@ -28,7 +28,6 @@ module Wechat
 
       raise 'Can not get corpid or appid, so please configure it first to using wechat_oauth2' if appid.blank?
 
-      api.jsapi_ticket.ticket if api.jsapi_ticket.oauth2_state.nil?
       oauth2_params = {
         appid: appid,
         redirect_uri: page_url || generate_redirect_uri(account),

--- a/lib/wechat/ticket/jsapi_base.rb
+++ b/lib/wechat/ticket/jsapi_base.rb
@@ -6,18 +6,17 @@ module Wechat
     class JsapiBase
       attr_reader :client, :access_token, :jsapi_ticket_file, :access_ticket, :ticket_life_in_seconds, :got_ticket_at
 
-      EXPIREING_SECONDS = 100
-
       def initialize(client, access_token, jsapi_ticket_file)
         @client = client
         @access_token = access_token
         @jsapi_ticket_file = jsapi_ticket_file
+        @random_generator = Random.new
       end
 
       def ticket(tries = 2)
         # Possible two worker running, one worker refresh ticket, other unaware, so must read every time
         read_ticket_from_store
-        refresh if remain_life_seconds < EXPIREING_SECONDS
+        refresh if remain_life_seconds < @random_generator.rand(30..3 * 60)
         access_ticket
       rescue AccessTokenExpiredError
         access_token.refresh
@@ -25,7 +24,7 @@ module Wechat
       end
 
       def oauth2_state
-        if @oauth2_state.blank? || remain_life_seconds < EXPIREING_SECONDS
+        if @oauth2_state.blank? || remain_life_seconds < 180
           ticket
         end
         @oauth2_state


### PR DESCRIPTION
判断 oauth2_state 是否过期，而不是只判断是否为空
避免过期导致多台部署机器 oauth2_state 不一致问题