### PR TITLE
custom_message_send 内使用 JSON.generate 来对消息做序列化

### DIFF
--- a/lib/wechat/concern/common.rb
+++ b/lib/wechat/concern/common.rb
@@ -151,7 +151,7 @@ module Wechat
       end
 
       def custom_message_send(message)
-        post 'message/custom/send', message.to_json, content_type: :json
+        post 'message/custom/send', JSON.generate(message), content_type: :json
       end
 
       def customservice_getonlinekflist

--- a/lib/wechat/concern/common.rb
+++ b/lib/wechat/concern/common.rb
@@ -151,7 +151,7 @@ module Wechat
       end
 
       def custom_message_send(message)
-        post 'message/custom/send', JSON.generate(message), content_type: :json
+        post 'message/custom/send', message.is_a?(Wechat::Message) ? message.to_json : JSON.generate(message), content_type: :json
       end
 
       def customservice_getonlinekflist

--- a/lib/wechat/corp_api.rb
+++ b/lib/wechat/corp_api.rb
@@ -162,7 +162,7 @@ module Wechat
     end
 
     def custom_message_send(message)
-      post 'message/send', message.agent_id(agentid).to_json, content_type: :json
+      post 'message/send', JSON.generate(message.agent_id(agentid)), content_type: :json
     end
   end
 end

--- a/lib/wechat/corp_api.rb
+++ b/lib/wechat/corp_api.rb
@@ -162,7 +162,7 @@ module Wechat
     end
 
     def custom_message_send(message)
-      post 'message/send', JSON.generate(message.agent_id(agentid)), content_type: :json
+      post 'message/send', message.is_a?(Wechat::Message) ? message.agent_id(agentid).to_json : JSON.generate(message.merge(agent_id: agentid)), content_type: :json
     end
   end
 end

--- a/spec/lib/wechat/api_spec.rb
+++ b/spec/lib/wechat/api_spec.rb
@@ -498,7 +498,7 @@ RSpec.describe Wechat::Api do
       }
 
       expect(subject.client).to receive(:post)
-        .with('message/custom/send', payload.to_json,
+        .with('message/custom/send', JSON.generate(payload),
               params: { access_token: 'access_token' }, content_type: :json).and_return(true)
 
       expect(subject.custom_message_send Wechat::Message.to('openid').text('message content')).to be true

--- a/spec/lib/wechat/corp_api_spec.rb
+++ b/spec/lib/wechat/corp_api_spec.rb
@@ -497,7 +497,7 @@ RSpec.describe Wechat::CorpApi do
       }
 
       expect(subject.client).to receive(:post)
-                                    .with('message/send', payload.to_json,
+                                    .with('message/send', JSON.generate(payload),
                                           params: { access_token: 'access_token' }, content_type: :json).and_return(true)
 
       expect(subject.custom_message_send Wechat::Message.to('openid').text('message content')).to be true


### PR DESCRIPTION
 to_json 会将消息内部分字符做 unicode escape, 导致微信侧显示出错