### PR TITLE
Read oauth2_state from ticket store every time to avoid invalid oauth2_state

### DIFF
--- a/lib/wechat/ticket/corp_jsapi_ticket.rb
+++ b/lib/wechat/ticket/corp_jsapi_ticket.rb
@@ -5,7 +5,7 @@ module Wechat
     class CorpJsapiTicket < JsapiBase
       def refresh
         data = client.get('get_jsapi_ticket', params: { access_token: access_token.token })
-        @oauth2_state = data['oauth2_state'] = SecureRandom.hex(16)
+        data['oauth2_state'] = SecureRandom.hex(16)
         write_ticket_to_store(data)
         read_ticket_from_store
       end

--- a/lib/wechat/ticket/jsapi_base.rb
+++ b/lib/wechat/ticket/jsapi_base.rb
@@ -24,9 +24,7 @@ module Wechat
       end
 
       def oauth2_state
-        if @oauth2_state.blank? || remain_life_seconds < 180
-          ticket
-        end
+        ticket
         @oauth2_state
       end
 

--- a/lib/wechat/ticket/public_jsapi_ticket.rb
+++ b/lib/wechat/ticket/public_jsapi_ticket.rb
@@ -5,7 +5,7 @@ module Wechat
     class PublicJsapiTicket < JsapiBase
       def refresh
         data = client.get('ticket/getticket', params: { access_token: access_token.token, type: 'jsapi' })
-        @oauth2_state = data['oauth2_state'] = SecureRandom.hex(16)
+        data['oauth2_state'] = SecureRandom.hex(16)
         write_ticket_to_store(data)
         read_ticket_from_store
       end


### PR DESCRIPTION
每次获取 oauth2_state 均通过 read ticket store，避免其它服务器把 ticket 刷新后，有的进程还使用旧值。