### PR TITLE
Responder 自动配置多账户

### DIFF
--- a/lib/action_controller/wechat_responder.rb
+++ b/lib/action_controller/wechat_responder.rb
@@ -10,6 +10,7 @@ module ActionController
     def wechat_responder(opts = {})
       include Wechat::Responder
       account = opts.delete(:account)
+      self.account_from_request = opts.delete(:account_from_request)
       self.wechat_cfg_account = account ? account.to_sym : :default
       self.wechat_api_client = load_controller_wechat(wechat_cfg_account, opts)
     end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -4,4 +4,7 @@ Rails.application.routes.draw do
 
   get 'wechat_corp', to: 'wechat_corp#show'
   post 'wechat_corp', to: 'wechat_corp#create'
+
+  get  'wechat_accounts', to: 'wechat_accounts#show'
+  post 'wechat_accounts', to: 'wechat_accounts#create'
 end

--- a/spec/lib/wechat/responder_accounts_spec.rb
+++ b/spec/lib/wechat/responder_accounts_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+
+class WechatAccountsController < ActionController::Base
+  wechat_responder account_from_request: Proc.new{|request| request.params[:account] }
+  on :text, with: /^cmd:(.*)$/ do |message, cmd|
+    message.reply.text("cmd: #{cmd}")
+  end
+end
+
+RSpec.describe WechatAccountsController, type: :controller do
+  def xml_to_hash(response)
+    Hash.from_xml(response.body)['xml'].symbolize_keys
+  end
+
+  before(:each) do
+    allow(WechatConfig).to receive(:get_all_configs).with(ENV['RAILS_ENV']).and_return({
+        :account_1 => {
+            appid: 'appid_1', secret: 'secret_1',
+            token: 'token_1', access_token: 'tmp/access_token_1', jsapi_ticket: 'tmp/jsapi_ticket_1',
+        },
+        :account_2 => {
+            appid: 'appid_2', secret: 'secret_2',
+            token: 'token_2', access_token: 'tmp/access_token_2', jsapi_ticket: 'tmp/jsapi_ticket_2',
+        },
+    })
+    Wechat.reload_config!
+  end
+
+  after(:each) { Wechat::ApiLoader.class_eval { @configs = nil } }
+
+  render_views
+
+  let(:signature_params_1) do
+    timestamp = '111111'
+    nonce = 'nonce_1'
+    signature = Digest::SHA1.hexdigest(['token_1', timestamp, nonce].sort.join)
+    { timestamp: timestamp, nonce: nonce, signature: signature }
+  end
+
+  let(:signature_params_2) do
+    timestamp = '222222'
+    nonce = 'nonce_2'
+    signature = Digest::SHA1.hexdigest(['token_2', timestamp, nonce].sort.join)
+    { timestamp: timestamp, nonce: nonce, signature: signature }
+  end
+
+  let(:text_message) do
+    message_base = {
+        ToUserName: 'toUser',
+        FromUserName: 'fromUser',
+        CreateTime: '1348831860',
+        MsgId: '1234567890123456'
+    }
+    message_base.merge(MsgType: 'text', Content: 'text message')
+  end
+
+  context 'when there is no account param' do
+    it 'uses global config' do
+      expect(controller.class.wechat).to eq(Wechat.api)
+      expect(controller.class.token).to eq(Wechat.config.token)
+    end
+  end
+
+  context 'when there is account param' do
+    it 'succeeds on correct account' do
+      post :create, params: signature_params_1.merge(xml: text_message, account: 'account_1')
+      expect(response.code).to eq('200')
+
+      post :create, params: signature_params_2.merge(xml: text_message, account: 'account_2')
+      expect(response.code).to eq('200')
+    end
+
+    it 'fails on incorrect account' do
+      post :create, params: signature_params_1.merge(xml: text_message, account: 'account_2')
+      expect(response.code).to eq('403')
+
+      post :create, params: signature_params_2.merge(xml: text_message, account: 'account_1')
+      expect(response.code).to eq('403')
+    end
+
+    it 'raises error on unspecified account' do
+      expect{
+        post :create, params: signature_params_1.merge(xml: text_message, account: 'invalid_account')
+      }.to raise_error
+    end
+
+    it 'responds to message' do
+      post :create, params: signature_params_1.merge(xml: text_message.merge(Content: 'cmd:command1'), account: 'account_1')
+      expect(xml_to_hash(response)[:Content]).to eq('cmd: command1')
+    end
+  end
+end


### PR DESCRIPTION
## 使用方法
```ruby
class WechatFirstController < ActionController::Base
   wechat_responder account: :new_account, account_from_request: Proc.new{ |request| request.params[:wechat] }

   on :text, with:"help", respond: "help content"
end
```

或者直接完整配置

```ruby
class WechatFirstController < ActionController::Base
   wechat_responder appid: "app1", secret: "secret1", token: "token1", access_token: Rails.root.join("tmp/access_token1"),
                    account_from_request: Proc.new{ |request| request.params[:wechat] }

   on :text, with:"help", respond: "help content"
end
```

其中 `account_from_request` 是一个 `Proc`，接受 `request` 作为唯一参数，返回相应的微信账户名称。以上示例中，`controller` 会根据 `request` 中传入的 `wechat` 参数选择微信账户。如果没有提供 `account_from_request` 或者 `Proc` 的结果是 `nil`，则使用 `account` 或者完整配置。

## 实现原理
`Responder` 中新增以下 `before_action`：

```ruby
def config_account
  account = self.class.account_from_request&.call(request)
  config = account ? Wechat.config(account) : nil

  @encrypt_mode = config&.encrypt_mode || self.class.encrypt_mode
  @encoding_aes_key = config&.encoding_aes_key || self.class.encoding_aes_key
  @token = config&.token || self.class.token
  @corpid = config&.corpid || self.class.corpid
end
```

`show` 和 `create` 不再使用 `Responder` 的 class variable，改用 instance variable。这样实现的考虑是，不用改动现存 `wechat_api` 和 `wechat_responder` 的调用方法，用户仍然可以指定默认账户。另外改动 instance variable 相对安全，如果改动 class variable 和 `load_controller_wechat`，需要更多重构。
