### PR TITLE
FIX: `request_content` could be nil

### DIFF
--- a/lib/wechat/responder.rb
+++ b/lib/wechat/responder.rb
@@ -298,7 +298,7 @@ module Wechat
     end
 
     def request_encrypt_content
-      request_content['xml']['Encrypt']
+      request_content&.dig('xml', 'Encrypt')
     end
 
     def request_content


### PR DESCRIPTION
加密模式下 `request_encrypt_content` 方法里，`request_content` 可能为 `nil`