### PR TITLE
let Wechat::Message support textcard, test included

### DIFF
--- a/lib/wechat/message.rb
+++ b/lib/wechat/message.rb
@@ -104,6 +104,15 @@ module Wechat
       update(MsgType: 'text', Content: content)
     end
 
+    def textcard(title, description, url, btntxt)
+      update(MsgType: 'textcard', TextCard: {
+        title: title,
+        description: description,
+        url: url,
+        btntxt: btntxt
+      })
+    end
+
     def transfer_customer_service(kf_account = nil)
       if kf_account
         update(MsgType: 'transfer_customer_service', TransInfo: { KfAccount: kf_account })
@@ -187,6 +196,7 @@ module Wechat
     end
 
     TO_JSON_KEY_MAP = {
+      'TextCard'         => 'textcard',
       'ToUserName'       => 'touser',
       'ToWxName'         => 'towxname',
       'MediaId'          => 'media_id',
@@ -198,7 +208,7 @@ module Wechat
       'ShowCoverPic'     => 'show_cover_pic'
     }.freeze
 
-    TO_JSON_ALLOWED = %w[touser msgtype content image voice video file
+    TO_JSON_ALLOWED = %w[touser msgtype content image voice video file textcard
                          music news articles template agentid filter
                          send_ignore_reprint mpnews towxname].freeze
 

--- a/spec/lib/wechat/message_spec.rb
+++ b/spec/lib/wechat/message_spec.rb
@@ -119,6 +119,14 @@ RSpec.describe Wechat::Message do
       end
     end
 
+    describe '#textcard' do
+      specify 'will update MsgType and TextCard field and return self' do
+        expect(message.textcard('title', 'content', 'URL', '更多')).to eq(message)
+        expect(message[:MsgType]).to eq 'textcard'
+        expect(message[:TextCard]).to eq ({btntxt: '更多', description: 'content', title: 'title', url: 'URL'})
+      end
+    end
+
     describe '#transfer_customer_service' do
       specify 'will update MsgType and return self' do
         expect(message.transfer_customer_service).to eq(message)


### PR DESCRIPTION
Wechat has supported several other new media types, including textcard, which is really handy for sending messages containing `title`, `description`, `url` and `button text`.

Test added, and all tests passed.
[Doc for textcard media type](https://work.weixin.qq.com/api/doc#90000/90135/90236)