### PR TITLE
let Message support markdown, text included; allow textcard btntxt to be omitted

### DIFF
--- a/lib/wechat/message.rb
+++ b/lib/wechat/message.rb
@@ -104,12 +104,19 @@ module Wechat
       update(MsgType: 'text', Content: content)
     end
 
-    def textcard(title, description, url, btntxt)
-      update(MsgType: 'textcard', TextCard: {
+    def textcard(title, description, url, btntxt = nil)
+      data = {
         title: title,
         description: description,
-        url: url,
-        btntxt: btntxt
+        url: url
+      }
+      data[:btntxt] = btntxt if btntxt.present?
+      update(MsgType: 'textcard', TextCard: data)
+    end
+
+    def markdown(content)
+      update(MsgType: 'markdown', Markdown: {
+        content: content
       })
     end
 
@@ -197,6 +204,7 @@ module Wechat
 
     TO_JSON_KEY_MAP = {
       'TextCard'         => 'textcard',
+      'Markdown'         => 'markdown',
       'ToUserName'       => 'touser',
       'ToWxName'         => 'towxname',
       'MediaId'          => 'media_id',
@@ -208,7 +216,7 @@ module Wechat
       'ShowCoverPic'     => 'show_cover_pic'
     }.freeze
 
-    TO_JSON_ALLOWED = %w[touser msgtype content image voice video file textcard
+    TO_JSON_ALLOWED = %w[touser msgtype content image voice video file textcard markdown
                          music news articles template agentid filter
                          send_ignore_reprint mpnews towxname].freeze
 

--- a/spec/lib/wechat/message_spec.rb
+++ b/spec/lib/wechat/message_spec.rb
@@ -125,6 +125,20 @@ RSpec.describe Wechat::Message do
         expect(message[:MsgType]).to eq 'textcard'
         expect(message[:TextCard]).to eq ({btntxt: '更多', description: 'content', title: 'title', url: 'URL'})
       end
+
+      specify 'btntxt can be omited' do
+        expect(message.textcard('title', 'content', 'URL')).to eq(message)
+        expect(message[:MsgType]).to eq 'textcard'
+        expect(message[:TextCard]).to eq ({description: 'content', title: 'title', url: 'URL'})
+      end
+    end
+
+    describe '#markdown' do
+      specify 'will update MsgType and Markdown field and return self' do
+        expect(message.markdown('[这是一个链接](http://work.weixin.qq.com/api/doc)')).to eq(message)
+        expect(message[:MsgType]).to eq 'markdown'
+        expect(message[:Markdown]).to eq ({content: '[这是一个链接](http://work.weixin.qq.com/api/doc)'})
+      end
     end
 
     describe '#transfer_customer_service' do


### PR DESCRIPTION
Wechat has supported `markdown`, which is much easier to write complex messages than other media types such as `textcard`, `text`. 

Another reason of its importance is that, unlike `textcard`, text in which will be omitted once it's becoming a bit longer, one could write very very long text with `markdown`. 

This commit added support for `markdown`. (**Test included**)

Besides that, this commit enables sending textcard without `btntxt` cause wechat corp provides default value `详情` if `btntxt` is omitted. (**Test included**)

**All tests passed**
[Doc for `markdown` media type](https://work.weixin.qq.com/api/doc#90000/90135/90236/markdown%E6%B6%88%E6%81%AF)