### PR TITLE
Detailed doc of using muti-accounts, naming and translation fix

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -192,24 +192,18 @@ test:
  #  secret: "my_secret"
 ```
 
-支持多微信公众平台或企业微信账号
+支持 微信公众平台/企业微信 多账号的注意点(例如，增加账号`wx2`):
 
-使用方法
-1.配置文件可增加多个微信公众平台(企业微信)配置，用法类似 Rails 中 database.yml 多数据库配置的处理
-development, test, production 段是默认配置
-[account_env] 是额外微信公众平台(企业微信)配置，如
-wx007_development, wx007_test, wx007_production 增加了 wx007 这个微信公众平台(企业微信)的相关配置。
+* 配置文件可增加多个微信公众平台(企业微信)配置，用法类似Rails中`config/database.yml`多数据库配置的处理。`development`, `test`, `production`是默认账号的配置段，要想增加账号`wx2`，你需要增加配置段`wx2_development`, `wx2_test`, `wx2_production`。
 
-2.wechat_responder 声明
-wechat_responder account: :wx007
+* 声明账号`wx2`的`wechat_responder`:
+  ```ruby
+  wechat_responder account: :wx2
+  ```
 
-3.wechat api 使用
-Wechat.api(:wx007) 表示使用 wx007 这个微信公众平台(企业微信)的 api
-Wechat.api 和 Wechat.api(:default) 表示默认的 api
+* `Wechat.api(:wx2)` 表示使用账号`wx2`的Wechat api，而`Wechat.api`或`Wechat.api(:default)`则表示默认账号的wechat api。
 
-4.wechat 命令行使用
-增加可选参数 -a, [--account=ACCOUNT]
-如 wechat users -a wx007 表示列举 wx007 这个微信公众平台(企业微信)的粉丝列表
+* 在wechat命令行中，通过增加可选参数`-a, [--account=ACCOUNT]`来表示使用其他账号，例如`wechat users -a wx2`表示列举`wx2`这个账号的粉丝列表
 
 进一步的多账号支持参见[PR 150](https://github.com/Eric-Guo/wechat/pull/150)。
 

--- a/README-CN.md
+++ b/README-CN.md
@@ -3,13 +3,13 @@ WeChat [![Gem Version](https://badge.fury.io/rb/wechat.svg)](https://rubygems.or
 
 [![Join the chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/Eric-Guo/wechat?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-WeChat gem 可以帮助开发者方便地在Rails环境中集成微信[公众平台](https://mp.weixin.qq.com/)和[企业平台](https://qy.weixin.qq.com)提供的服务，包括：
+WeChat gem帮助开发者方便地在Rails环境中集成[微信公众平台](https://mp.weixin.qq.com/)和[企业微信](https://qy.weixin.qq.com)，包括功能：
 
-- 微信公众/企业平台[主动消息](http://qydev.weixin.qq.com/wiki/index.php?title=%E5%8F%91%E9%80%81%E6%B6%88%E6%81%AF)API（命令行和Web环境都可以使用）
-- [回调消息](http://qydev.weixin.qq.com/wiki/index.php?title=%E6%8E%A5%E6%94%B6%E6%B6%88%E6%81%AF%E4%B8%8E%E4%BA%8B%E4%BB%B6)（必须运行Web服务器）
+- 微信公众平台/企业微信[发送消息](http://qydev.weixin.qq.com/wiki/index.php?title=%E5%8F%91%E9%80%81%E6%B6%88%E6%81%AF)API（命令行和Web环境都可以使用）
+- [接收消息](http://qydev.weixin.qq.com/wiki/index.php?title=%E6%8E%A5%E6%94%B6%E6%B6%88%E6%81%AF%E4%B8%8E%E4%BA%8B%E4%BB%B6)（必须运行Web服务器）
 - [微信JS-SDK](http://qydev.weixin.qq.com/wiki/index.php?title=%E5%BE%AE%E4%BF%A1JS%E6%8E%A5%E5%8F%A3) config接口注入权限验证
 - OAuth 2.0认证机制
-- 回调消息会话(session)记录机制（可选）
+- 接收消息会话(session)记录机制（可选）
 
 命令行工具`wechat`可以调用各种无需web环境的API。同时也提供了Rails Controller的responder DSL, 可以帮助开发者方便地在Rails应用中集成微信的消息处理，包括主动推送的和被动响应的消息。
 

--- a/README-CN.md
+++ b/README-CN.md
@@ -107,7 +107,7 @@ access_token: "C:/Users/[user_name]/wechat_access_token"
 #### Rails 全局配置
 Rails应用程序中，需要将配置文件放在`config/wechat.yml`，可以为不同environment创建不同的配置。
 
-公众号配置示例：
+微信公众平台配置示例：
 
 ```
 default: &default
@@ -133,7 +133,7 @@ test:
   <<: *default
 ```
 
-公众号可选安全模式（加密模式），通过添加如下配置可开启加密模式。
+微信公众平台可选安全模式（加密模式），通过添加如下配置可开启加密模式。
 
 ```
 default: &default
@@ -141,7 +141,7 @@ default: &default
   encoding_aes_key:  "my_encoding_aes_key"
 ```
 
-企业号配置下必须使用加密模式，其中token和encoding_aes_key可以从企业号管理界面的应用中心->某个应用->模式选择，选择回调模式后获得。
+企业微信配置下必须使用加密模式，其中token和encoding_aes_key可以从企业号管理界面的应用中心->某个应用->模式选择，选择回调模式后获得。
 
 ```
 default: &default
@@ -191,6 +191,25 @@ test:
  #  appid: "my_appid"
  #  secret: "my_secret"
 ```
+
+支持多微信公众平台或企业微信账号
+
+使用方法
+1.配置文件可增加多个微信公众平台(企业微信)配置，用法类似 Rails 中 database.yml 多数据库配置的处理
+development, test, production 段是默认配置
+[account_env] 是额外微信公众平台(企业微信)配置，如
+wx007_development, wx007_test, wx007_production 增加了 wx007 这个微信公众平台(企业微信)的相关配置。
+
+2.wechat_responder 声明
+wechat_responder account: :wx007
+
+3.wechat api 使用
+Wechat.api(:wx007) 表示使用 wx007 这个微信公众平台(企业微信)的 api
+Wechat.api 和 Wechat.api(:default) 表示默认的 api
+
+4.wechat 命令行使用
+增加可选参数 -a, [--account=ACCOUNT]
+如 wechat users -a wx007 表示列举 wx007 这个微信公众平台(企业微信)的粉丝列表
 
 进一步的多账号支持参见[PR 150](https://github.com/Eric-Guo/wechat/pull/150)。
 
@@ -298,7 +317,7 @@ class CartController < ActionController::Base
 end
 ```
 
-企业号可使用如下代码取得企业用户的相关信息。
+企业微信可使用如下代码取得企业用户的相关信息。
 
 ```ruby
 class WechatsController < ActionController::Base
@@ -326,9 +345,9 @@ wechat gems 内部不会检查权限。但因公众号类型不同，和微信�
 
 ## 使用命令行
 
-根据企业号和公众号配置不同，wechat提供了的命令行命令。
+根据企业微信和微信公众平台配置不同，wechat提供了的命令行命令。
 
-#### 公众号命令行
+#### 微信公众平台命令行
 
 ```
 $ wechat
@@ -385,11 +404,11 @@ Wechat Public Account commands:
   wechat wxacode_download [WXA_CODE_PIC_PATH, PATH, WIDTH]      # 下载小程序码
 ```
 
-#### 企业号命令行
+#### 企业微信命令行
 ```
 $ wechat
 Wechat Enterprise Account commands:
-  wechat agent [AGENT_ID]                                       # 获取企业号应用详情
+  wechat agent [AGENT_ID]                                       # 获取企业微信应用详情
   wechat agent_list                                             # 获取应用概况列表
   wechat batch_job_result [JOB_ID]                              # 获取异步任务结果
   wechat batch_replaceparty [BATCH_PARTY_CSV_MEDIA_ID]          # 全量覆盖部门
@@ -595,7 +614,7 @@ wechat.template_message_send Wechat::Message.to(openid).template(template['templ
 
 ## wechat_api - Rails Controller Wechat API
 
-虽然用户可以随时通过`Wechat.api`在任意代码中访问wechat的API功能，但是更推荐的做法是仅在controller中，通过引入`wechat_api`，使用`wechat`调用API功能，不仅因为这样是支持多个微信公众号的必然要求，而且也避免了在模型层内过多引入微信相关代码。
+虽然用户可以随时通过`Wechat.api`在任意代码中访问wechat的API功能，但是更推荐的做法是仅在controller中，通过引入`wechat_api`，使用`wechat`调用API功能，不仅因为这样是支持多个微信公众平台账号的必然要求，而且也避免了在模型层内过多引入微信相关代码。
 
 ```ruby
 class WechatReportsController < ApplicationController
@@ -650,12 +669,12 @@ class WechatsController < ActionController::Base
     request.reply.text "User #{request[:FromUserName]} subscribe now"
   end
 
-  # 公众号收到未关注用户扫描qrscene_xxxxxx二维码时。注意此次扫描事件将不再引发上条的用户加关注事件
+  # 公众平台收到未关注用户扫描qrscene_xxxxxx二维码时。注意此次扫描事件将不再引发上条的用户加关注事件
   on :scan, with: 'qrscene_xxxxxx' do |request, ticket|
     request.reply.text "Unsubscribe user #{request[:FromUserName]} Ticket #{ticket}"
   end
 
-  # 公众号收到已关注用户扫描创建二维码的scene_id事件时
+  # 公众平台收到已关注用户扫描创建二维码的scene_id事件时
   on :scan, with: 'scene_id' do |request, ticket|
     request.reply.text "Subscribe user #{request[:FromUserName]} Ticket #{ticket}"
   end
@@ -667,12 +686,12 @@ class WechatsController < ActionController::Base
     end
   end
 
-  # 企业号收到EventKey 为二维码扫描结果事件时
+  # 企业微信收到EventKey 为二维码扫描结果事件时
   on :scan, with: 'BINDING_QR_CODE' do |request, scan_result, scan_type|
     request.reply.text "User #{request[:FromUserName]} ScanResult #{scan_result} ScanType #{scan_type}"
   end
 
-  # 企业号收到EventKey 为CODE 39码扫描结果事件时
+  # 企业微信收到EventKey 为CODE 39码扫描结果事件时
   on :scan, with: 'BINDING_BARCODE' do |message, scan_result|
     if scan_result.start_with? 'CODE_39,'
       message.reply.text "User: #{message[:FromUserName]} scan barcode, result is #{scan_result.split(',')[1]}"
@@ -812,6 +831,6 @@ end
 
 ## 已知问题
 
-* 企业号接受菜单消息时，Wechat腾讯服务器无法解析部分域名，请使用IP绑定回调URL，用户的普通消息目前不受影响。
-* 企业号全量覆盖成员使用的csv通讯录格式，直接将下载的模板导入[是不工作的](http://qydev.weixin.qq.com/qa/index.php?qa=13978)，必须使用Excel打开，然后另存为csv格式才会变成合法格式。
+* 企业微信接受菜单消息时，Wechat腾讯服务器无法解析部分域名，请使用IP绑定回调URL，用户的普通消息目前不受影响。
+* 企业微信全量覆盖成员使用的csv通讯录格式，直接将下载的模板导入[是不工作的](http://qydev.weixin.qq.com/qa/index.php?qa=13978)，必须使用Excel打开，然后另存为csv格式才会变成合法格式。
 * 如果使用nginx+unicron部署方案，并且使用了https，必须设置`trusted_domain_fullname`为https，否则会导致JS-SDK签名失效。

--- a/README.md
+++ b/README.md
@@ -206,18 +206,21 @@ test:
  #  secret: "my_secret"
 ```
 
-Support multiple accounts
+Notes about supporting multiple accounts of `WeChat Official Accounts Platform` / `WeChat Enterprise` (for example, adding account `wx2`):
 
-Instructions
-1.The configuration file can be added to multiple WeChat Official Accounts Platform or WeChat Enterprise configuration, the usage is similar to the database.yml multi-database configuration in Rails. Development, test, production segment is the default configuration [account_env] is the additional WeChat Official Accounts Platform or WeChat Enterprise configuration, For example, wx007_development, wx007_test, wx007_production added the configuration of wx007, the WeChat public platform (Enterprise WeChat).
+* Configuration for multiple accounts is similar to multi-database configuration in `config/database.yml`,
+   where `development`, `test`, `production` segments are the default configuration, one needs to add `wx2_development`, `wx2_test`, `wx2_production` in order to add additional account named `wx2`.
 
-2.wechat_responder declaration wechat_responder account: :wx007
+* Declaration of additional `wechat_responder`:
+  ```ruby
+  wechat_responder account: :wx2
+  ```
 
-3.Wechat api uses Wechat.api(:wx007) to use wx007, the WeChat Official Accounts Platform or WeChat Enterprise api Wechat.api and Wechat.api(:default) to represent the default api.
+* Use `Wechat.api` or `Wechat.api(:default)` to represent the default wechat api. Use `Wechat.api(:wx2)` to call for wechat api of account `wx2`.
 
-4.Wechat command line use to add optional parameters -a, [--account=ACCOUNT] such as wechat users -a wx007 to list wx007 This WeChat Official Accounts Platform fan list
+* When using `Wechat command line`, one can switch to another wechat account by adding optional parameters `-a ACCOUNT [--account=ACCOUNT]`.
 
-For multiple accounts details reference [PR 150](https://github.com/Eric-Guo/wechat/pull/150)
+For details about supporting multiple accounts, please check [PR 150](https://github.com/Eric-Guo/wechat/pull/150)
 
 For wechat mini program, can specified by the item `type`:
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ WeChat [![Gem Version](https://badge.fury.io/rb/wechat.svg)](https://rubygems.or
 
 [Wechat](http://www.wechat.com/) is a Chinese multi-purpose messaging, social media and mobile payment app developed by Tencent. It was first released in 2011, and by 2018 it was one of the world's largest standalone mobile apps by monthly active users, with over 1 billion monthly active users (902 million daily active users). (According to [wiki](https://en.wikipedia.org/wiki/WeChat))
 
-WeChat gem tries to help Rails developers to integrate [enterprise account](https://qy.weixin.qq.com) / [public account](https://mp.weixin.qq.com/) easily. Features below are ready and there is no need to write adapter code for talking to wechat server directly.
+WeChat gem helps Rails developers integrate [WeChat Official Accounts Platform](https://mp.weixin.qq.com/) and [Wechat Enterprise](https://qy.weixin.qq.com) easily, including features:
 
-- [Sending message](http://qydev.weixin.qq.com/wiki/index.php?title=%E5%8F%91%E9%80%81%E6%B6%88%E6%81%AF) API（Can access via console or in rails）
-- [Receiving message](http://qydev.weixin.qq.com/wiki/index.php?title=%E6%8E%A5%E6%94%B6%E6%B6%88%E6%81%AF%E4%B8%8E%E4%BA%8B%E4%BB%B6)（You must run rails server to receive messages）
+- [Sending message](http://qydev.weixin.qq.com/wiki/index.php?title=%E5%8F%91%E9%80%81%E6%B6%88%E6%81%AF) API（can be both accessed via console or rails server）
+- [Receiving message](http://qydev.weixin.qq.com/wiki/index.php?title=%E6%8E%A5%E6%94%B6%E6%B6%88%E6%81%AF%E4%B8%8E%E4%BA%8B%E4%BB%B6)（rails server is required to be running）
 - [Wechat JS-SDK](http://qydev.weixin.qq.com/wiki/index.php?title=%E5%BE%AE%E4%BF%A1JS%E6%8E%A5%E5%8F%A3) config signature
 - OAuth 2.0 authentication
 - Record session when receiving message from user (Optional)

--- a/README.md
+++ b/README.md
@@ -206,6 +206,17 @@ test:
  #  secret: "my_secret"
 ```
 
+Support multiple accounts
+
+Instructions
+1.The configuration file can be added to multiple WeChat Official Accounts Platform or WeChat Enterprise configuration, the usage is similar to the database.yml multi-database configuration in Rails. Development, test, production segment is the default configuration [account_env] is the additional WeChat Official Accounts Platform or WeChat Enterprise configuration, For example, wx007_development, wx007_test, wx007_production added the configuration of wx007, the WeChat public platform (Enterprise WeChat).
+
+2.wechat_responder declaration wechat_responder account: :wx007
+
+3.Wechat api uses Wechat.api(:wx007) to use wx007, the WeChat Official Accounts Platform or WeChat Enterprise api Wechat.api and Wechat.api(:default) to represent the default api.
+
+4.Wechat command line use to add optional parameters -a, [--account=ACCOUNT] such as wechat users -a wx007 to list wx007 This WeChat Official Accounts Platform fan list
+
 For multiple accounts details reference [PR 150](https://github.com/Eric-Guo/wechat/pull/150)
 
 For wechat mini program, can specified by the item `type`:


### PR DESCRIPTION
* We had got couple of issues when we were about to try multiple accounts in a single project. Thus we made a detailed doc about it.

* naming and translation fix, such as `微信公众` -> `微信公众平台`, `企业平台` -> `企业微信` (this naming is changed recently).
