### PR TITLE
Use secret to differentiate different acces_tokens and tickets, test fix

### DIFF
--- a/lib/generators/wechat/templates/config/initializers/wechat_redis_store.rb
+++ b/lib/generators/wechat/templates/config/initializers/wechat_redis_store.rb
@@ -17,7 +17,7 @@ module Wechat
       private
 
       def redis_key
-        "my_app_wechat_token_#{self.appid}"
+        "my_app_wechat_token_#{self.secret}"
       end
     end
   end
@@ -35,7 +35,7 @@ module Wechat
       private
 
       def redis_key
-        "my_app_wechat_ticket_#{self.access_token.appid}"
+        "my_app_wechat_ticket_#{self.access_token.secret}"
       end
     end
   end

--- a/spec/lib/wechat/corp_api_spec.rb
+++ b/spec/lib/wechat/corp_api_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Wechat::CorpApi do
       now = Time.now
       starttime = now.beginning_of_day
       endtime = now.end_of_day
-      checkin_request = { useridlist: useridlist, opencheckindatatype: 3, starttime: starttime.to_i, endtime: endtime.to_i }
+      checkin_request = { opencheckindatatype: 3, starttime: starttime.to_i, endtime: endtime.to_i, useridlist: useridlist }
       checkin_result = { errcode: 0, errmsg: 'ok',
                          checkindata: [{ userid: 'userid',
                                          groupname: '打卡测试',


### PR DESCRIPTION
微信允许使用同一个Corp App ID，但是不同的Corp App Secret去访问不同体系的api，两种不同体系的api所需要的access_token是不同的，这个时候如果使用App ID去区分存储access token，会产生冲突，解决办法之一就是使用secret去区分access tokens