### PR TITLE
allow a message to be sent to a party(department)

### DIFF
--- a/lib/wechat/message.rb
+++ b/lib/wechat/message.rb
@@ -15,6 +15,10 @@ module Wechat
         end
       end
 
+      def to_party(party)
+        new(ToPartyName: party, CreateTime: Time.now.to_i)
+      end
+
       def to_mass(tag_id: nil, send_ignore_reprint: 0)
         if tag_id
           new(filter: { is_to_all: false, tag_id: tag_id }, send_ignore_reprint: send_ignore_reprint)
@@ -206,6 +210,7 @@ module Wechat
       'TextCard'         => 'textcard',
       'Markdown'         => 'markdown',
       'ToUserName'       => 'touser',
+      'ToPartyName'     => 'toparty',
       'ToWxName'         => 'towxname',
       'MediaId'          => 'media_id',
       'MpNews'           => 'mpnews',
@@ -216,7 +221,7 @@ module Wechat
       'ShowCoverPic'     => 'show_cover_pic'
     }.freeze
 
-    TO_JSON_ALLOWED = %w[touser msgtype content image voice video file textcard markdown
+    TO_JSON_ALLOWED = %w[touser toparty msgtype content image voice video file textcard markdown
                          music news articles template agentid filter
                          send_ignore_reprint mpnews towxname].freeze
 

--- a/spec/lib/wechat/message_spec.rb
+++ b/spec/lib/wechat/message_spec.rb
@@ -39,6 +39,16 @@ RSpec.describe Wechat::Message do
     end
   end
 
+  describe 'to_party' do
+    let(:message) { Wechat::Message.from_hash(text_request) }
+    specify 'will create a message sent to a party' do
+      reply = Wechat::Message.to_party(2)
+      expect(reply).to be_a(Wechat::Message)
+      expect(reply.message_hash).to include(ToPartyName: 2)
+      expect(reply.message_hash[:CreateTime]).to be_a(Integer)
+    end
+  end
+
   describe 'to_mass' do
     let(:message) { Wechat::Message.from_hash(text_request) }
     specify 'will create base message' do


### PR DESCRIPTION
Many of corp wechat's apis allow a message to be sent to a party(department), for example, `text api`:
```
{
   "touser" : "UserID1|UserID2|UserID3",
   "toparty" : "PartyID1|PartyID2",
   "totag" : "TagID1 | TagID2",
   "msgtype" : "image",
   "agentid" : 1,
   "image" : {
        "media_id" : "MEDIA_ID"
   },
   "safe":0
}

```

Thus, I added `to_party` of `Wechat::Message` which allows a customized message been sent to a party(department).

Test attached, all tests passed