### PR TITLE
修复 class_exists? 方法判断不准确

### DIFF
--- a/lib/wechat/api_loader.rb
+++ b/lib/wechat/api_loader.rb
@@ -137,9 +137,10 @@ module Wechat
     end
 
     private_class_method def self.class_exists?(class_name)
-      return Module.const_get(class_name).present?
+      klass = Module.const_get(class_name)
+      klass.is_a?(Class)
     rescue NameError
-      return false
+      false
     end
   end
 end


### PR DESCRIPTION
如果不小心用了`WechatConfig = 'test'`这样的赋值常量，那`WechatConfig`并不是一个`class`，之前的`class_exists?`方法有这样的一个小漏洞。