### PR TITLE
CHG: upgrade ssl_version to 1.2

### DIFF
--- a/lib/wechat/http_client.rb
+++ b/lib/wechat/http_client.rb
@@ -14,7 +14,7 @@ module Wechat
                   HTTP.timeout(:global, write: timeout, connect: timeout, read: timeout)
                 end
       @ssl_context = OpenSSL::SSL::SSLContext.new
-      @ssl_context.ssl_version = :TLSv1
+      @ssl_context.ssl_version = :TLSv1_2
       @ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE if skip_verify_ssl
     end
 


### PR DESCRIPTION
```
ubuntu@20.04:~$ curl -v --tls-max 1.0 https://api.weixin.qq.com
*   Trying 183.57.48.62:443...
* TCP_NODELAY set
* Connected to api.weixin.qq.com (183.57.48.62) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/certs/ca-certificates.crt
  CApath: /etc/ssl/certs
* TLSv1.3 (OUT), TLS alert, internal error (592):
* error:141E70BF:SSL routines:tls_construct_client_hello:no protocols available
* Closing connection 0
curl: (35) error:141E70BF:SSL routines:tls_construct_client_hello:no protocols available
```

Ubuntu 20.04 LTS (Focal Fossa) 默认已经不支持 TLS 1.0、1.1 了
