### PR TITLE
支持微信open_tag

### DIFF
--- a/lib/wechat/helpers.rb
+++ b/lib/wechat/helpers.rb
@@ -34,7 +34,8 @@ module Wechat
           timestamp: "#{js_hash[:timestamp]}",
           nonceStr: "#{js_hash[:noncestr]}",
           signature: "#{js_hash[:signature]}",
-          jsApiList: ['#{config_options[:api].join("','")}']
+          jsApiList: ['#{config_options[:api].join("','")}'],
+          openTagList: ['#{config_options[:open_tags].join("','")}']
         });
       WECHAT_CONFIG_JS
       javascript_tag config_js, type: 'application/javascript'


### PR DESCRIPTION
微信升级了 js-sdk 支持 微信开放标签，可以在 h5 中打开小程序以及 app：

https://developers.weixin.qq.com/doc/offiaccount/OA_Web_Apps/Wechat_Open_Tag.html#21

```js
wx.config({
  debug: true, // 开启调试模式,调用的所有api的返回值会在客户端alert出来，若要查看传入的参数，可以在pc端打开，参数信息会通过log打出，仅在pc端时才会打印
  appId: '', // 必填，公众号的唯一标识
  timestamp: , // 必填，生成签名的时间戳
  nonceStr: '', // 必填，生成签名的随机串
  signature: '',// 必填，签名
  jsApiList: [], // 必填，需要使用的JS接口列表
  openTagList: [] // 可选，需要使用的开放标签列表，例如['wx-open-launch-app']
});
```