### PR TITLE
Feat: add account_type to WechatConfig

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -227,6 +227,7 @@ test:
 environment | 字串 | 必填。配置对应的运行环境，一般有：`production`、`development`、`test`。比如  `production`  配置仅在生产环境有效。默认为  `development`。 
 account | 字串 | 必填。自定义的微信账户名称。同一  `environment`  下，账户名称不允许重复。 
 enabled | 布尔 | 必填。配置是否生效。默认  `true`。 
+account_type | 字串 | 非必填。当前只支持`mp`,表示小程序。
 appid | 字串 | 公众号 id ，此字段和  `corpid`  两者必填其一。 
 secret | 字串 | 公众号相关配置。当公众号  `appid`  存在时必填。 
 corpid | 字串 | 企业号 id。此字段和 `appid` 两者必填其一。

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Attribute | Type | Annotation
 ---- | ---- | ----
 environment | string | Required. Environment of account configuration. Typical values are: `production`, `development` and `test`. For example, a `production` config will only be available in `production`. Default to `development`.
 account | string | Required. Custom wechat account name. Account names must be unique within each environment.
+account_type | string | account type, only support `mp` which is short for `mini program` currently
 enabled | boolean | Required. Whether this configuration is activated. Default to `true`.
 appid | string | Public account id. Either this attribute or `corpid` must be specified.
 secret | string | Public account configuration. Required when `appid` exists.

--- a/lib/generators/wechat/templates/app/models/wechat_config.rb
+++ b/lib/generators/wechat/templates/app/models/wechat_config.rb
@@ -9,10 +9,11 @@ class WechatConfig < ActiveRecord::Base
   validates :access_token, presence: true
   validates :jsapi_ticket, presence: true
   validates :encoding_aes_key, presence: { if: :encrypt_mode? }
+  validates :account_type, inclusion: { in: %w[mp] }, if: -> { account_type.present? }
 
   validate :app_config_is_valid
 
-  ATTRIBUTES_TO_REMOVE = %w[environment account created_at updated_at enabled].freeze
+  ATTRIBUTES_TO_REMOVE = %w[environment account created_at updated_at enabled account_type].freeze
 
   def self.get_all_configs(environment)
     WechatConfig.where(environment: environment, enabled: true).each_with_object({}) do |config, hash|
@@ -21,7 +22,9 @@ class WechatConfig < ActiveRecord::Base
   end
 
   def build_config_hash
-    as_json(except: ATTRIBUTES_TO_REMOVE)
+    config_hash = as_json(except: ATTRIBUTES_TO_REMOVE)
+    config_hash[:type] = account_type if account_type.present?
+    config_hash
   end
 
   private

--- a/lib/generators/wechat/templates/db/config_migration.rb.erb
+++ b/lib/generators/wechat/templates/db/config_migration.rb.erb
@@ -5,6 +5,8 @@ class CreateWechatConfigs < ActiveRecord::Migration<%= migration_version %>
       t.string :environment, null: false, default: 'development'
       # account name
       t.string :account, null: false
+      # account type, "mp" is short for mini program
+      t.string :account_type
       # whether this config is activated
       t.boolean :enabled, default: true
 

--- a/spec/lib/wechat/wechat_config_spec.rb
+++ b/spec/lib/wechat/wechat_config_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe WechatConfig, type: :model do
     described_class.new(
         environment: 'test',
         account: 'account',
+        account_type: 'mp',
         enabled: true,
 
         appid: 'appid',
@@ -157,6 +158,10 @@ RSpec.describe WechatConfig, type: :model do
       WechatConfig::ATTRIBUTES_TO_REMOVE.each do |attribute|
         expect(config_hash).to_not have_key attribute
       end
+    end
+
+    it 'has account_type set to "mp"' do
+      expect(test_account.account_type).to eq 'mp'
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define do
   create_table :wechat_configs do |t|
     t.string :environment, null: false, default: 'development'
     t.string :account, null: false
+    t.string :account_type
     t.boolean :enabled, default: true
     t.string :appid
     t.string :secret


### PR DESCRIPTION
When using Wechat.api(:account) with a database config, the method now returns an MpApi instance when account_type is specifically set to 'mp'. This ensures the correct API type is used based on account configuration.