### PR TITLE
chore: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,11 @@
 ## Commit & Pull Request Guidelines
 - Write concise, imperative commit messages; conventional prefixes (`feat:`, `fix:`, `chore:`) are welcome and present in history.
 - Keep commits focused; update docs/examples when APIs or configuration change.
+
+## Cursor Cloud specific instructions
+
+- **System dependencies**: Ruby 3.2, `libsqlite3-dev`, `libyaml-dev`, and `build-essential` are installed via the update script. Gems are installed to `vendor/bundle` (bundler path config is set locally).
+- **Running tests + lint**: `bundle exec rake` runs RSpec then RuboCop in one step. See "Build, Test, and Development Commands" above for targeted test/lint commands.
+- **CLI usage**: The `wechat` CLI (`bundle exec wechat help`) requires a `~/.wechat.yml` with at least `appid` and `secret` keys. Without valid WeChat credentials, API commands will fail with HTTP errors, but `help` works fine with dummy values.
+- **No external services required**: All tests mock HTTP and use in-memory SQLite. No Redis, Docker, or real WeChat API access is needed.
+- **Coverage**: SimpleCov output goes to `coverage/index.html`; currently at ~96.5% line coverage.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with key notes for future cloud agents:

- System dependencies (Ruby 3.2, libsqlite3-dev, libyaml-dev, build-essential)
- Gems installed to `vendor/bundle` via local bundler path config
- CLI usage note (`~/.wechat.yml` required with at least dummy credentials for `help`)
- Confirmation that no external services are needed (all tests mock HTTP, use in-memory SQLite)
- SimpleCov coverage location and current level (~96.5%)

**Testing evidence:**

[rake_output.log](https://cursor.com/agents/bc-d11a55bf-db2d-43f3-b6cd-71c8a01d4362/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frake_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d11a55bf-db2d-43f3-b6cd-71c8a01d4362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d11a55bf-db2d-43f3-b6cd-71c8a01d4362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

