### PR TITLE
chore: bump RuboCop development dependency to ~> 1.84.2

### DIFF
--- a/wechat.gemspec
+++ b/wechat.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rexml'
   s.add_runtime_dependency 'zeitwerk', '~> 2.4'
 
-  s.add_development_dependency 'rubocop', '~> 1.81.7'
+  s.add_development_dependency 'rubocop', '~> 1.84.2'
   s.add_development_dependency 'rails', '>= 7.2'
   s.add_development_dependency 'rspec-rails', '~> 8.0'
   s.add_development_dependency 'rspec-mocks', '~> 3.13'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the development dependency on RuboCop from `~> 1.81.7` to `~> 1.84.2` so the constraint matches RuboCop **1.84.2**, which is required by **standard** **1.54.0** and other tooling on that line.

## Verification

- `bundle update rubocop` resolves to **1.84.2**.
- `bundle exec rake` (328 examples) and `bundle exec rubocop` both pass.

## Notes

- `Gemfile.lock` remains gitignored; contributors should run `bundle install` / `bundle update rubocop` locally after pulling.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fa1b716-7be7-455c-8d9c-1efd97f5ee9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fa1b716-7be7-455c-8d9c-1efd97f5ee9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

