### PR TITLE
ci(semaphore): switch to f1-standard-2 and Ubuntu 22.04

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3,8 +3,8 @@ version: v1.0
 name: wechat gems
 agent:
   machine:
-    type: e1-standard-2
-    os_image: ubuntu2004
+    type: f1-standard-2
+    os_image: ubuntu2204
 blocks:
   - name: Test
     task:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Semaphore reported the job stuck **waiting on `e1-standard-2` quota** (see [job](https://mixtint.semaphoreci.com/jobs/f308edc3-a4eb-4dc1-a22c-f2c19e003093)). Many organizations no longer allocate E1 capacity in favor of newer generations.

## Change

- **Machine:** `e1-standard-2` → **`f1-standard-2`** (current Semaphore Cloud F1 tier, same 2 vCPU class as documented).
- **OS image:** `ubuntu2004` → **`ubuntu2204`** so the agent matches [supported Ubuntu images](https://docs.semaphoreci.com/ci-cd-environment/machine-types/) for E2/F1 (22.04 / 24.04).

Existing steps (`sem-version ruby 3.2.6`, `bundle install`, `rspec`) are unchanged.

## Verification

- `bundle exec rake` passes locally (unchanged Ruby code).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fa1b716-7be7-455c-8d9c-1efd97f5ee9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fa1b716-7be7-455c-8d9c-1efd97f5ee9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

